### PR TITLE
Support direct media URLs and multiple URLs in one message

### DIFF
--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -1,6 +1,8 @@
 defmodule SaveIt.Bot do
   require Logger
 
+  import SaveIt.SmallHelper.UrlHelper, only: [direct_media_url?: 1]
+
   alias SaveIt.FileHelper
   alias SaveIt.GoogleDrive
   alias SaveIt.GoogleOAuth2DeviceFlow
@@ -245,84 +247,13 @@ defmodule SaveIt.Bot do
     urls = extract_urls_from_string(text)
 
     unless Enum.empty?(urls) do
-      {:ok, progress_message} = send_message(chat.id, Enum.at(@progress, 0))
-      url = List.first(urls)
+      has_success? =
+        urls
+        |> Enum.map(&process_url(chat.id, &1))
+        |> Enum.any?(&(&1 == :ok))
 
-      case Cobalt.get_download_url(url) do
-        {:ok, purge_url, download_urls} ->
-          case FileHelper.get_downloaded_files(download_urls) do
-            nil ->
-              update_message(chat.id, progress_message.message_id, Enum.slice(@progress, 0..1))
-
-              case WebDownloader.download_files(download_urls) do
-                {:ok, files} ->
-                  update_message(
-                    chat.id,
-                    progress_message.message_id,
-                    Enum.slice(@progress, 0..2)
-                  )
-
-                  # TODO: send media group
-                  # bot_send_media_group(chat.id, files)
-                  bot_send_files(chat.id, files)
-
-                  delete_messages(chat.id, [message_id, progress_message.message_id])
-                  FileHelper.write_folder(purge_url, files)
-                  # TODO: 给图片添加 emoji
-                  GoogleDrive.upload_files(chat.id, files)
-
-                _ ->
-                  update_message(
-                    chat.id,
-                    progress_message.message_id,
-                    "💔 Failed downloading file."
-                  )
-              end
-
-            downloaded_files ->
-              update_message(chat.id, progress_message.message_id, Enum.slice(@progress, 0..2))
-
-              # TODO: bot_send_media_group(chat.id, downloaded_files)
-              bot_send_filenames(chat.id, downloaded_files)
-              delete_messages(chat.id, [message_id, progress_message.message_id])
-          end
-
-        {:ok, download_url} ->
-          case FileHelper.get_downloaded_file(download_url) do
-            nil ->
-              update_message(chat.id, progress_message.message_id, Enum.slice(@progress, 0..1))
-
-              case WebDownloader.download_file(download_url) do
-                {:ok, file_name, file_content} ->
-                  update_message(
-                    chat.id,
-                    progress_message.message_id,
-                    Enum.slice(@progress, 0..2)
-                  )
-
-                  bot_send_file(chat.id, file_name, {:file_content, file_content, file_name})
-
-                  delete_messages(chat.id, [message_id, progress_message.message_id])
-                  FileHelper.write_file(file_name, file_content, download_url)
-                  GoogleDrive.upload_file_content(chat.id, file_content, file_name)
-
-                _ ->
-                  update_message(
-                    chat.id,
-                    progress_message.message_id,
-                    "💔 Failed downloading file."
-                  )
-              end
-
-            downloaded_file ->
-              update_message(chat.id, progress_message.message_id, Enum.slice(@progress, 0..2))
-
-              bot_send_file(chat.id, downloaded_file, {:file, downloaded_file})
-              delete_messages(chat.id, [message_id, progress_message.message_id])
-          end
-
-        {:error, _} ->
-          update_message(chat.id, progress_message.message_id, "💔 Failed to get download URL.")
+      if has_success? do
+        delete_message(chat.id, message_id)
       end
     end
   end
@@ -385,6 +316,87 @@ defmodule SaveIt.Bot do
     Enum.map(matches, fn [url] -> url end)
   end
 
+  defp get_download_url(url) do
+    if direct_media_url?(url) do
+      {:ok, url}
+    else
+      Cobalt.get_download_url(url)
+    end
+  end
+
+  defp process_url(chat_id, url) do
+    {:ok, progress_message} = send_message(chat_id, Enum.at(@progress, 0))
+    progress_message_id = progress_message.message_id
+
+    case get_download_url(url) do
+      {:ok, purge_url, download_urls} ->
+        case FileHelper.get_downloaded_files(download_urls) do
+          nil ->
+            update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..1))
+
+            case WebDownloader.download_files(download_urls) do
+              {:ok, files} ->
+                update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
+
+                # TODO: send media group
+                # bot_send_media_group(chat.id, files)
+                bot_send_files(chat_id, files)
+
+                delete_message(chat_id, progress_message_id)
+                FileHelper.write_folder(purge_url, files)
+                # TODO: 给图片添加 emoji
+                GoogleDrive.upload_files(chat_id, files)
+                :ok
+
+              _ ->
+                update_message(chat_id, progress_message_id, "💔 Failed downloading file.")
+                :error
+            end
+
+          downloaded_files ->
+            update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
+
+            # TODO: bot_send_media_group(chat.id, downloaded_files)
+            bot_send_filenames(chat_id, downloaded_files)
+            delete_message(chat_id, progress_message_id)
+            :ok
+        end
+
+      {:ok, download_url} ->
+        case FileHelper.get_downloaded_file(download_url) do
+          nil ->
+            update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..1))
+
+            case WebDownloader.download_file(download_url) do
+              {:ok, file_name, file_content} ->
+                update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
+
+                bot_send_file(chat_id, file_name, {:file_content, file_content, file_name})
+
+                delete_message(chat_id, progress_message_id)
+                FileHelper.write_file(file_name, file_content, download_url)
+                GoogleDrive.upload_file_content(chat_id, file_content, file_name)
+                :ok
+
+              _ ->
+                update_message(chat_id, progress_message_id, "💔 Failed downloading file.")
+                :error
+            end
+
+          downloaded_file ->
+            update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
+
+            bot_send_file(chat_id, downloaded_file, {:file, downloaded_file})
+            delete_message(chat_id, progress_message_id)
+            :ok
+        end
+
+      {:error, _} ->
+        update_message(chat_id, progress_message_id, "💔 Failed to get download URL.")
+        :error
+    end
+  end
+
   defp send_message(chat_id, text) do
     ExGram.send_message(chat_id, text)
   end
@@ -399,10 +411,6 @@ defmodule SaveIt.Bot do
 
   defp delete_message(chat_id, message_id) do
     ExGram.delete_message(chat_id, message_id)
-  end
-
-  defp delete_messages(chat_id, message_ids) do
-    Enum.each(message_ids, fn message_id -> delete_message(chat_id, message_id) end)
   end
 
   defp bot_send_files(chat_id, files) do

--- a/lib/save_it/small_helper/url_helper.ex
+++ b/lib/save_it/small_helper/url_helper.ex
@@ -1,4 +1,27 @@
 defmodule SaveIt.SmallHelper.UrlHelper do
+  @media_extensions MapSet.new([
+                      "jpg",
+                      "jpeg",
+                      "png",
+                      "gif",
+                      "webp",
+                      "bmp",
+                      "tiff",
+                      "avif",
+                      "svg",
+                      "mp4",
+                      "webm",
+                      "mov",
+                      "m4v",
+                      "mkv",
+                      "mp3",
+                      "m4a",
+                      "aac",
+                      "wav",
+                      "ogg",
+                      "flac"
+                    ])
+
   def validate_url!(url) do
     uri = URI.parse(url)
 
@@ -7,5 +30,38 @@ defmodule SaveIt.SmallHelper.UrlHelper do
     else
       raise ArgumentError, "Invalid URL: #{url}"
     end
+  end
+
+  def direct_media_url?(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: scheme, host: host} = uri
+      when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        ext_from_path =
+          uri.path
+          |> Path.extname()
+          |> String.trim_leading(".")
+          |> String.downcase()
+
+        ext_from_query =
+          case uri.query do
+            nil -> nil
+            query -> URI.decode_query(query) |> Map.get("format")
+          end
+
+        media_extension?(ext_from_path) or media_extension?(ext_from_query)
+
+      _ ->
+        false
+    end
+  end
+
+  def direct_media_url?(_), do: false
+
+  defp media_extension?(nil), do: false
+
+  defp media_extension?(ext) do
+    ext
+    |> String.downcase()
+    |> then(&MapSet.member?(@media_extensions, &1))
   end
 end

--- a/test/url_helper_test.exs
+++ b/test/url_helper_test.exs
@@ -1,0 +1,21 @@
+defmodule SaveIt.SmallHelper.UrlHelperTest do
+  use ExUnit.Case, async: true
+
+  alias SaveIt.SmallHelper.UrlHelper
+
+  test "direct_media_url?/1 returns true for media extension in path" do
+    assert UrlHelper.direct_media_url?(
+             "https://docs.expo.dev/static/videos/tutorial/01-navigating-between-screens.mp4"
+           )
+  end
+
+  test "direct_media_url?/1 returns true for media format in query" do
+    assert UrlHelper.direct_media_url?(
+             "https://pbs.twimg.com/media/GV52FRqaoAA-O8A?format=jpg&name=large"
+           )
+  end
+
+  test "direct_media_url?/1 returns false for non media page url" do
+    refute UrlHelper.direct_media_url?("https://example.com/article?id=1")
+  end
+end


### PR DESCRIPTION
## Summary
- support direct media URL detection (path extension and format query)
- bypass Cobalt for direct media URLs and download them directly
- process all URLs found in one message instead of only the first one
- add tests for direct media URL detection

## Test
- mix test