### PR TITLE
Support bad.news video URLs with HLS downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Support bad.news video URLs with HLS (m3u8) stream downloading via ffmpeg.
+- Auto-select best video quality that fits within Telegram's 50MB upload limit.
+
+### Changed
+- Added ffmpeg to Dockerfile for HLS video support.
+
 ## [0.2.0] - 2026-04-26
 
 ### Highlights

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM elixir:1.17.2
 RUN apt-get update && \
     apt-get install -y \
     build-essential \
+    ffmpeg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Save images and videos from internet.
 - [x] https://www.pinterest.com/
 - [x] https://instagram.com/
 - [x] https://www.youtube.com/
+- [x] https://bad.news/
 
 ## Usage
 
@@ -52,6 +53,7 @@ https://github.com/user-attachments/assets/b0dedcc0-3305-42b2-8101-6b0b5d32f17a
 - [Elixir](https://elixir-lang.org/)
 - [ex_gram](https://github.com/rockneurotiko/ex_gram) a powerful Elixir library for building Telegram Bots.
 - [cobalt](https://github.com/imputnet/cobalt) a media downloader.
+- [ffmpeg](https://ffmpeg.org/) for HLS video downloading.
 - [Typesense](https://typesense.org/) Lightning Fast, Open Source Search
 
 

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -11,6 +11,8 @@ defmodule SaveIt.Bot do
 
   alias SmallSdk.Telegram
   alias SmallSdk.Cobalt
+  alias SmallSdk.BadNews
+  alias SmallSdk.HlsDownloader
   alias SmallSdk.WebDownloader
 
   @bot :save_it_bot
@@ -317,10 +319,15 @@ defmodule SaveIt.Bot do
   end
 
   defp get_download_url(url) do
-    if direct_media_url?(url) do
-      {:ok, url}
-    else
-      Cobalt.get_download_url(url)
+    cond do
+      direct_media_url?(url) ->
+        {:ok, url}
+
+      BadNews.bad_news_url?(url) ->
+        BadNews.get_download_url(url)
+
+      true ->
+        Cobalt.get_download_url(url)
     end
   end
 
@@ -329,6 +336,25 @@ defmodule SaveIt.Bot do
     progress_message_id = progress_message.message_id
 
     case get_download_url(url) do
+      {:ok, m3u8_url, :hls} ->
+        update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..1))
+
+        case HlsDownloader.download(m3u8_url) do
+          {:ok, file_name, file_content} ->
+            update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
+
+            bot_send_file(chat_id, file_name, {:file_content, file_content, file_name})
+
+            delete_message(chat_id, progress_message_id)
+            FileHelper.write_file(file_name, file_content, url)
+            GoogleDrive.upload_file_content(chat_id, file_content, file_name)
+            :ok
+
+          {:error, _reason} ->
+            update_message(chat_id, progress_message_id, "💔 Failed downloading HLS video.")
+            :error
+        end
+
       {:ok, purge_url, download_urls} ->
         case FileHelper.get_downloaded_files(download_urls) do
           nil ->

--- a/lib/small_sdk/bad_news.ex
+++ b/lib/small_sdk/bad_news.ex
@@ -12,6 +12,8 @@ defmodule SmallSdk.BadNews do
     - `{:error, reason}` on failure
   """
   def get_download_url(page_url) do
+    page_url = normalize_url(page_url)
+
     case Req.get(page_url, headers: [{"User-Agent", "Mozilla/5.0"}]) do
       {:ok, %{status: 200, body: body}} ->
         extract_video_info(body)
@@ -62,6 +64,14 @@ defmodule SmallSdk.BadNews do
           _ ->
             {:error, "No video found on bad.news page"}
         end
+    end
+  end
+
+  # Normalize /ajax/topic/{id}/download to /t/{id} (ajax page requires login)
+  defp normalize_url(url) do
+    case Regex.run(~r|/ajax/topic/(\d+)/download|, url) do
+      [_, id] -> @base_url <> "/t/" <> id
+      _ -> url
     end
   end
 

--- a/lib/small_sdk/bad_news.ex
+++ b/lib/small_sdk/bad_news.ex
@@ -1,0 +1,75 @@
+defmodule SmallSdk.BadNews do
+  require Logger
+
+  @base_url "https://bad.news"
+
+  @doc """
+  Extract the main video download URL from a bad.news topic page.
+
+  Returns:
+    - `{:ok, video_url}` for direct mp4 videos
+    - `{:ok, m3u8_url, :hls}` for HLS streams
+    - `{:error, reason}` on failure
+  """
+  def get_download_url(page_url) do
+    case Req.get(page_url, headers: [{"User-Agent", "Mozilla/5.0"}]) do
+      {:ok, %{status: 200, body: body}} ->
+        extract_video_info(body)
+
+      {:ok, %{status: status}} ->
+        {:error, "bad.news returned status #{status}"}
+
+      {:error, reason} ->
+        Logger.error("Failed to fetch bad.news page: #{inspect(reason)}")
+        {:error, "Failed to fetch bad.news page"}
+    end
+  end
+
+  def bad_news_url?(url) do
+    case URI.parse(url) do
+      %URI{host: host} when is_binary(host) ->
+        host == "bad.news" or String.ends_with?(host, ".bad.news")
+
+      _ ->
+        false
+    end
+  end
+
+  defp extract_video_info(html) do
+    # Match the first <video> element with data-source and data-type attributes
+    video_regex =
+      ~r/<video[^>]*?data-source="([^"]+)"[^>]*?data-type="([^"]+)"/s
+
+    case Regex.run(video_regex, html) do
+      [_, source, "mp4"] ->
+        {:ok, ensure_absolute_url(source)}
+
+      [_, source, "m3u8"] ->
+        {:ok, ensure_absolute_url(source), :hls}
+
+      _ ->
+        # Try reversed attribute order
+        reversed_regex =
+          ~r/<video[^>]*?data-type="([^"]+)"[^>]*?data-source="([^"]+)"/s
+
+        case Regex.run(reversed_regex, html) do
+          [_, "mp4", source] ->
+            {:ok, ensure_absolute_url(source)}
+
+          [_, "m3u8", source] ->
+            {:ok, ensure_absolute_url(source), :hls}
+
+          _ ->
+            {:error, "No video found on bad.news page"}
+        end
+    end
+  end
+
+  defp ensure_absolute_url(url) do
+    if String.starts_with?(url, "http") do
+      url
+    else
+      @base_url <> url
+    end
+  end
+end

--- a/lib/small_sdk/hls_downloader.ex
+++ b/lib/small_sdk/hls_downloader.ex
@@ -1,0 +1,176 @@
+defmodule SmallSdk.HlsDownloader do
+  require Logger
+
+  # Telegram bot API file upload limit is 50MB
+  @max_file_size 49 * 1024 * 1024
+
+  @doc """
+  Download an HLS (m3u8) stream and convert it to mp4 using ffmpeg.
+  Automatically selects a variant that fits within Telegram's 50MB limit.
+
+  Returns `{:ok, filename, binary_content}` or `{:error, reason}`.
+  """
+  def download(m3u8_url) do
+    base_url = extract_base_url(m3u8_url)
+
+    with {:ok, master_body} <- fetch(m3u8_url),
+         {:ok, variants} <- parse_master_playlist(master_body, base_url) do
+      download_best_variant(variants, m3u8_url)
+    end
+  end
+
+  defp download_best_variant([], _original_url) do
+    {:error, "No suitable HLS variant found"}
+  end
+
+  defp download_best_variant([variant | rest], original_url) do
+    filename = gen_filename(original_url) <> ".mp4"
+    tmp_path = Path.join(System.tmp_dir!(), filename)
+
+    Logger.info("HLS: trying variant #{variant.resolution} (#{variant.bandwidth} bps)")
+
+    args =
+      build_ffmpeg_args(variant, tmp_path)
+
+    try do
+      case System.cmd("ffmpeg", args, stderr_to_stdout: true) do
+        {_output, 0} ->
+          case File.read(tmp_path) do
+            {:ok, content} when byte_size(content) > @max_file_size ->
+              Logger.warning(
+                "HLS: variant #{variant.resolution} too large (#{div(byte_size(content), 1024 * 1024)}MB), trying lower quality"
+              )
+
+              File.rm(tmp_path)
+              download_best_variant(rest, original_url)
+
+            {:ok, content} when byte_size(content) > 0 ->
+              {:ok, filename, content}
+
+            {:ok, _} ->
+              {:error, "ffmpeg produced an empty file"}
+
+            {:error, reason} ->
+              {:error, "Failed to read ffmpeg output: #{inspect(reason)}"}
+          end
+
+        {output, exit_code} ->
+          Logger.error("ffmpeg failed (exit #{exit_code}): #{output}")
+          download_best_variant(rest, original_url)
+      end
+    rescue
+      e in ErlangError ->
+        Logger.error("ffmpeg not found: #{inspect(e)}")
+        {:error, "ffmpeg is not installed"}
+    after
+      File.rm(tmp_path)
+    end
+  end
+
+  defp build_ffmpeg_args(variant, tmp_path) do
+    case variant.audio_url do
+      nil ->
+        ["-i", variant.url, "-c", "copy", "-y", "-loglevel", "warning", tmp_path]
+
+      audio_url ->
+        [
+          "-i", variant.url,
+          "-i", audio_url,
+          "-c", "copy",
+          "-y",
+          "-loglevel", "warning",
+          tmp_path
+        ]
+    end
+  end
+
+  defp fetch(url) do
+    case Req.get(url) do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, %{status: status}} -> {:error, "HLS fetch failed with status #{status}"}
+      {:error, reason} -> {:error, "HLS fetch failed: #{inspect(reason)}"}
+    end
+  end
+
+  defp parse_master_playlist(body, base_url) do
+    lines = String.split(body, "\n", trim: true)
+
+    # Parse audio tracks: GROUP-ID -> absolute URL
+    audio_map =
+      lines
+      |> Enum.filter(&String.starts_with?(&1, "#EXT-X-MEDIA:"))
+      |> Enum.filter(&String.contains?(&1, "TYPE=AUDIO"))
+      |> Enum.reduce(%{}, fn line, acc ->
+        group_id = extract_attr(line, "GROUP-ID")
+        uri = extract_attr(line, "URI")
+
+        if group_id && uri do
+          Map.put(acc, group_id, resolve_url(uri, base_url))
+        else
+          acc
+        end
+      end)
+
+    # Parse video variants: resolution, bandwidth, audio group, URL
+    variants =
+      lines
+      |> Enum.chunk_every(2, 1, :discard)
+      |> Enum.filter(fn [info, _url] -> String.starts_with?(info, "#EXT-X-STREAM-INF:") end)
+      |> Enum.map(fn [info, url_line] ->
+        bandwidth = extract_attr(info, "BANDWIDTH") |> to_integer(0)
+        resolution = extract_attr(info, "RESOLUTION") || "unknown"
+        audio_group = extract_attr(info, "AUDIO")
+        audio_url = if audio_group, do: Map.get(audio_map, audio_group)
+
+        %{
+          url: resolve_url(url_line, base_url),
+          audio_url: audio_url,
+          bandwidth: bandwidth,
+          resolution: resolution
+        }
+      end)
+      # Sort by bandwidth descending so we try highest quality first
+      |> Enum.sort_by(& &1.bandwidth, :desc)
+
+    case variants do
+      [] -> {:error, "No variants found in HLS master playlist"}
+      variants -> {:ok, variants}
+    end
+  end
+
+  defp extract_attr(line, attr_name) do
+    # Handle both quoted and unquoted attribute values
+    regex = Regex.compile!("#{attr_name}=\"?([^\",\\s]+)\"?")
+
+    case Regex.run(regex, line) do
+      [_, value] -> value
+      _ -> nil
+    end
+  end
+
+  defp to_integer(nil, default), do: default
+
+  defp to_integer(str, default) do
+    case Integer.parse(str) do
+      {n, _} -> n
+      :error -> default
+    end
+  end
+
+  defp extract_base_url(url) do
+    uri = URI.parse(url)
+    "#{uri.scheme}://#{uri.host}"
+  end
+
+  defp resolve_url(path, base_url) do
+    if String.starts_with?(path, "http") do
+      path
+    else
+      base_url <> path
+    end
+  end
+
+  defp gen_filename(url) do
+    :crypto.hash(:sha256, url) |> Base.url_encode64(padding: false)
+  end
+end


### PR DESCRIPTION
## Summary
- Add custom extractor for bad.news that parses video sources (`data-source`) from HTML pages
- Download HLS (m3u8) streams via ffmpeg with automatic quality fallback to fit Telegram's 50MB upload limit
- Normalize `/ajax/topic/{id}/download` URLs to `/t/{id}` (ajax endpoint requires login)
- Add ffmpeg to Dockerfile

## Test plan
- [ ] Send `https://bad.news/t/{id}` with mp4 video to bot, verify download succeeds
- [ ] Send `https://bad.news/t/{id}` with m3u8 video to bot, verify HLS download and quality selection
- [ ] Send `https://bad.news/ajax/topic/{id}/download` URL, verify it normalizes and works
- [ ] Verify existing URL flows (direct media, Cobalt) are unaffected
- [ ] Verify ffmpeg is available in Docker image

🤖 Generated with [Claude Code](https://claude.com/claude-code)