### PR TITLE
feat: make telegram multi-image send as media group

### DIFF
--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -440,13 +440,51 @@ defmodule SaveIt.Bot do
   end
 
   defp bot_send_files(chat_id, files) do
-    Enum.each(files, fn {file_name, file_content} ->
-      bot_send_file(chat_id, file_name, {:file_content, file_content, file_name})
-    end)
+    if all_images?(files) and length(files) > 1 do
+      bot_send_media_group(
+        chat_id,
+        Enum.map(files, fn {file_name, file_content} ->
+          {file_name, {:file_content, file_content, file_name}}
+        end)
+      )
+    else
+      Enum.each(files, fn {file_name, file_content} ->
+        bot_send_file(chat_id, file_name, {:file_content, file_content, file_name})
+      end)
+    end
   end
 
   defp bot_send_filenames(chat_id, filenames) do
-    Enum.each(filenames, fn filename -> bot_send_file(chat_id, filename, {:file, filename}) end)
+    if all_images?(filenames) and length(filenames) > 1 do
+      bot_send_media_group(chat_id, Enum.map(filenames, fn filename -> {filename, {:file, filename}} end))
+    else
+      Enum.each(filenames, fn filename -> bot_send_file(chat_id, filename, {:file, filename}) end)
+    end
+  end
+
+  defp bot_send_media_group(chat_id, files) do
+    case Telegram.send_media_group(chat_id, files) do
+      {:ok, messages} ->
+        Enum.zip(files, messages)
+        |> Enum.each(fn {{_file_name, content}, msg} ->
+          file_id = get_file_id(msg)
+          image_base64 = encode_file_content(content)
+
+          PhotoService.create_photo!(%{
+            image: image_base64,
+            caption: "",
+            file_id: file_id,
+            belongs_to_id: chat_id
+          })
+        end)
+
+      {:error, reason} ->
+        Logger.error("Failed to send media group: #{inspect(reason)}")
+
+        Enum.each(files, fn {file_name, content} ->
+          bot_send_file(chat_id, file_name, content)
+        end)
+    end
   end
 
   defp bot_send_file(chat_id, file_name, file_content, opts \\ []) do
@@ -465,10 +503,7 @@ defmodule SaveIt.Bot do
         file_id = get_file_id(msg)
 
         image_base64 =
-          case file_content do
-            {:file, file} -> File.read!(file) |> Base.encode64()
-            {:file_content, file_content, _file_name} -> Base.encode64(file_content)
-          end
+          encode_file_content(file_content)
 
         PhotoService.create_photo!(%{
           image: image_base64,
@@ -492,11 +527,40 @@ defmodule SaveIt.Bot do
     Path.extname(file_name)
   end
 
+  defp all_images?(files) when is_list(files) do
+    Enum.all?(files, fn
+      {file_name, _file_content} ->
+        image_file?(file_name)
+
+      file_name when is_binary(file_name) ->
+        image_file?(file_name)
+    end)
+  end
+
+  defp image_file?(file_name) do
+    file_extension(file_name) in [".png", ".jpg", ".jpeg"]
+  end
+
+  defp encode_file_content({:file, file}) do
+    File.read!(file) |> Base.encode64()
+  end
+
+  defp encode_file_content({:file_content, file_content, _file_name}) do
+    Base.encode64(file_content)
+  end
+
   defp get_file_id(msg) do
-    case msg.photo do
+    photos =
+      cond do
+        is_map(msg) and Map.has_key?(msg, :photo) -> msg.photo
+        is_map(msg) and Map.has_key?(msg, "photo") -> msg["photo"]
+        true -> nil
+      end
+
+    case photos do
       photos when is_list(photos) and length(photos) > 0 ->
         photo = List.last(photos)
-        photo.file_id
+        Map.get(photo, :file_id) || Map.get(photo, "file_id")
 
       _ ->
         Logger.error("No photo found in the message")

--- a/lib/small_sdk/cobalt.ex
+++ b/lib/small_sdk/cobalt.ex
@@ -60,7 +60,7 @@ defmodule SmallSdk.Cobalt do
 
   def handle_response({:error, reason}) do
     Logger.error("Request failed: #{inspect(reason)}")
-    raise "Request failed"
+    {:error, "Request failed: #{inspect(reason)}"}
   end
 
   def handle_response!(%{status: status, body: body}) do

--- a/lib/small_sdk/telegram.ex
+++ b/lib/small_sdk/telegram.ex
@@ -5,6 +5,52 @@ defmodule SmallSdk.Telegram do
 
   plug(Tesla.Middleware.BaseUrl, "https://api.telegram.org")
 
+  def send_media_group(chat_id, files) when is_list(files) do
+    token = get_env()
+    path = "/bot#{token}/sendMediaGroup"
+
+    {media_entries, multipart} =
+      files
+      |> Enum.with_index()
+      |> Enum.reduce({[], Tesla.Multipart.new()}, fn {{_file_name, content}, index}, {media_acc, mp} ->
+        part_name = "media#{index}"
+
+        media = %{
+          type: "photo",
+          media: "attach://#{part_name}"
+        }
+
+        mp =
+          case content do
+            {:file, file_path} ->
+              Tesla.Multipart.add_file(mp, file_path, name: part_name)
+
+            {:file_content, file_content, file_name} ->
+              Tesla.Multipart.add_file_content(mp, file_content, file_name, name: part_name)
+          end
+
+        {[media | media_acc], mp}
+      end)
+
+    media_json = media_entries |> Enum.reverse() |> Jason.encode!()
+
+    multipart =
+      multipart
+      |> Tesla.Multipart.add_field("chat_id", to_string(chat_id))
+      |> Tesla.Multipart.add_field("media", media_json)
+
+    case post(path, multipart, headers: Tesla.Multipart.headers(multipart)) do
+      {:ok, %{status: status, body: body}} when status in 200..299 ->
+        decode_send_media_group_body(body)
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {:telegram_http_error, status, body}}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
   def download_file_content(file_path) when is_binary(file_path) do
     bot_token = get_env()
     url = "/file/bot#{bot_token}/#{file_path}"
@@ -24,6 +70,22 @@ defmodule SmallSdk.Telegram do
       {:error, error} -> raise "Error: #{inspect(error)}"
     end
   end
+
+  defp decode_send_media_group_body(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, %{"ok" => true, "result" => result}} ->
+        {:ok, result}
+
+      {:ok, decoded} ->
+        {:error, {:telegram_api_error, decoded}}
+
+      {:error, reason} ->
+        {:error, {:invalid_json_response, reason}}
+    end
+  end
+
+  defp decode_send_media_group_body(%{"ok" => true, "result" => result}), do: {:ok, result}
+  defp decode_send_media_group_body(body), do: {:error, {:telegram_api_error, body}}
 
   defp get_env() do
     bot_token = Application.fetch_env!(:save_it, :telegram_bot_token)

--- a/test/cobalt_test.exs
+++ b/test/cobalt_test.exs
@@ -1,0 +1,26 @@
+defmodule SmallSdk.CobaltTest do
+  use ExUnit.Case, async: true
+
+  alias SmallSdk.Cobalt
+
+  test "handle_response/1 returns ok for success status" do
+    response = {:ok, %{status: 200, body: %{"url" => "https://example.com/a.jpg"}}}
+
+    assert {:ok, %{"url" => "https://example.com/a.jpg"}} = Cobalt.handle_response(response)
+  end
+
+  test "handle_response/1 returns error tuple for non-2xx status" do
+    response = {:ok, %{status: 500, body: %{"error" => "internal"}}}
+
+    assert {:error, msg} = Cobalt.handle_response(response)
+    assert msg =~ "Request failed with status 500"
+  end
+
+  test "handle_response/1 does not raise on transport error" do
+    response = {:error, %Req.TransportError{reason: :econnrefused}}
+
+    assert {:error, msg} = Cobalt.handle_response(response)
+    assert msg =~ "Request failed"
+    assert msg =~ "econnrefused"
+  end
+end


### PR DESCRIPTION
## Summary
- send Telegram multi-image uploads via multipart `sendMediaGroup` with `attach://...` parts
- avoid `Jason.Encoder` crash caused by passing `{:file_content, ...}` tuples into JSON body
- keep graceful fallback to per-file sending if media-group API fails
- prevent bot process crash on Cobalt transport errors by returning `{:error, ...}` instead of raising
- add regression tests for `SmallSdk.Cobalt.handle_response/1`

## Changes
- `lib/small_sdk/telegram.ex`
  - add `send_media_group/2` using Tesla multipart
  - decode Telegram API response and surface structured errors
- `lib/save_it/bot.ex`
  - route multi-image sends to media-group path
  - use Telegram multipart media-group sender
  - keep existing per-file fallback behavior
  - make `get_file_id/1` compatible with atom/string-key maps
- `lib/small_sdk/cobalt.ex`
  - replace raise-on-transport-error with error tuple return
- `test/cobalt_test.exs`
  - add tests for success, non-2xx, and transport-error handling

## Verification

- `mix test` passes (`7 tests, 0 failures`)


https://x.com/JennerItGirls/status/2057529104535023815?s=20

<img width="1307" height="1114" alt="CleanShot 2026-05-23 at 21 24 31" src="https://github.com/user-attachments/assets/891ca6da-8f1b-4f06-82d2-2a37a8d8fae1" />

<img width="1064" height="820" alt="CleanShot 2026-05-23 at 21 24 55" src="https://github.com/user-attachments/assets/15378458-7f21-4a22-97d1-21bf326227c7" />
