### PR TITLE
fix: use config_env in runtime sentry config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix `mix ts.migrate` false failures when Typesense model initialization finishes after the client timeout but the collection was actually created.
 - Fix local media save failures caused by an outdated Typesense `photos` schema that still required `url` and did not include `file_id`.
+- Fix Sentry runtime configuration to use `config_env()` so releases do not call `Mix.env()` at boot.
 
 ## [0.4.0] - 2026-05-24
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -14,7 +14,7 @@ config :save_it, :google_oauth_client_secret, System.get_env("GOOGLE_OAUTH_CLIEN
 
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),
-  environment_name: Mix.env(),
+  environment_name: config_env(),
   enable_source_code_context: true,
   root_source_code_path: File.cwd!(),
   included_dependencies: [:req, :jason, :hackney]


### PR DESCRIPTION
## Summary
- replace `Mix.env()` with `config_env()` in `config/runtime.exs`
- add a changelog entry for the release boot fix
- keep Sentry runtime config safe for `mix release` boot

## Testing
- mix test
