### PR TITLE
fix: improve Telegram media uploads and Typesense search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project uses [Calendar Versioning](https://calver.org/) with the `YYYY.
 
 ## [Unreleased]
 
+### Fixed
+- Fix Telegram media group uploads for downloaded multi-image posts by accepting file tuples that also carry the source URL metadata.
+- Fix Typesense requests crashing in Finch by omitting `receive_timeout` unless a concrete timeout value is provided.
+
+### Changed
+- Add request and result logging around Typesense photo searches to make empty `/search` responses easier to diagnose in production logs.
+- Tune `/search` image semantic retrieval to use a `0.785` vector distance cutoff and log top vector distances for easier relevance calibration.
+
 ## [0.4.1] - 2026-05-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project uses [Calendar Versioning](https://calver.org/) with the `YYYY.
 ### Fixed
 - Fix Telegram media group uploads for downloaded multi-image posts by accepting file tuples that also carry the source URL metadata.
 - Fix Typesense requests crashing in Finch by omitting `receive_timeout` unless a concrete timeout value is provided.
+- Fix Docker Compose Cobalt tunnel downloads by returning an internal service URL instead of `localhost`, which is unreachable from the `save_it` container.
 
 ### Changed
 - Add request and result logging around Typesense photo searches to make empty `/search` responses easier to diagnose in production logs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - 9001:9000/tcp
     environment:
-      API_URL: "http://localhost:9001/"
+      API_URL: "http://cobalt-api:9000/"
 
   typesense:
     image: typesense/typesense:30.2

--- a/lib/save_it/photo_service.ex
+++ b/lib/save_it/photo_service.ex
@@ -68,7 +68,7 @@ defmodule SaveIt.PhotoService do
           "q" => q,
           "collection" => "photos",
           "prefix" => false,
-          "vector_query" => "image_embedding:([], k: 5, distance_threshold: 0.75)",
+          "vector_query" => "image_embedding:([], k: 20, distance_threshold: 0.785)",
           "filter_by" => "belongs_to_id:#{belongs_to_id}",
           "exclude_fields" => "image_embedding"
         }
@@ -78,6 +78,7 @@ defmodule SaveIt.PhotoService do
     req = build_request("/multi_search")
     res = Req.post(req, json: req_body)
     data = Typesense.handle_response(res)
+    log_search_response("search_photos", %{q: q, belongs_to_id: belongs_to_id}, data)
 
     results = data["results"]
 
@@ -111,6 +112,7 @@ defmodule SaveIt.PhotoService do
     req = build_request("/multi_search")
     res = Req.post(req, json: req_body)
     data = Typesense.handle_response(res)
+    log_search_response("search_similar_photos", %{photo_id: photo_id, belongs_to_id: belongs_to_id}, data)
 
     results = data["results"]
 
@@ -141,6 +143,29 @@ defmodule SaveIt.PhotoService do
         {"Content-Type", "application/json"},
         {"X-TYPESENSE-API-KEY", api_key}
       ]
+    )
+  end
+
+  defp log_search_response(action, metadata, data) do
+    results = Map.get(data, "results", [])
+    hits = results |> List.first(%{}) |> Map.get("hits", [])
+
+    hits_count =
+      length(hits)
+
+    top_vector_distances =
+      hits
+      |> Enum.take(5)
+      |> Enum.map(&Map.get(&1, "vector_distance"))
+
+    Logger.info(
+      "Typesense #{action} response: " <>
+        inspect(%{
+          metadata: metadata,
+          hits_count: hits_count,
+          top_vector_distances: top_vector_distances,
+          results: results
+        })
     )
   end
 end

--- a/lib/small_sdk/telegram.ex
+++ b/lib/small_sdk/telegram.ex
@@ -12,7 +12,8 @@ defmodule SmallSdk.Telegram do
     {media_entries, multipart} =
       files
       |> Enum.with_index()
-      |> Enum.reduce({[], Tesla.Multipart.new()}, fn {{_file_name, content}, index}, {media_acc, mp} ->
+      |> Enum.reduce({[], Tesla.Multipart.new()}, fn {file, index}, {media_acc, mp} ->
+        {_file_name, content} = media_group_file_parts(file)
         part_name = "media#{index}"
 
         media = %{
@@ -50,6 +51,9 @@ defmodule SmallSdk.Telegram do
         {:error, error}
     end
   end
+
+  defp media_group_file_parts({file_name, content, _source_url}), do: {file_name, content}
+  defp media_group_file_parts({file_name, content}), do: {file_name, content}
 
   def download_file_content(file_path) when is_binary(file_path) do
     bot_token = get_env()

--- a/lib/small_sdk/typesense.ex
+++ b/lib/small_sdk/typesense.ex
@@ -141,15 +141,22 @@ defmodule SmallSdk.Typesense do
   defp build_request(path, opts \\ []) do
     {url, api_key} = get_env()
 
-    Req.new(
+    req_opts = [
       base_url: url,
       url: path,
-      receive_timeout: Keyword.get(opts, :receive_timeout),
       headers: [
         {"Content-Type", "application/json"},
         {"X-TYPESENSE-API-KEY", api_key}
       ]
-    )
+    ]
+
+    req_opts =
+      case Keyword.fetch(opts, :receive_timeout) do
+        {:ok, receive_timeout} -> Keyword.put(req_opts, :receive_timeout, receive_timeout)
+        :error -> req_opts
+      end
+
+    Req.new(req_opts)
   end
 
   def handle_response({:ok, %{status: status, body: body}}) do

--- a/lib/small_sdk/typesense.ex
+++ b/lib/small_sdk/typesense.ex
@@ -138,10 +138,24 @@ defmodule SmallSdk.Typesense do
     {url, api_key}
   end
 
-  defp build_request(path, opts \\ []) do
+  defp build_request(path, opts \\ [])
+
+  defp build_request(path, receive_timeout: receive_timeout) do
+    base_request_opts(path)
+    |> Keyword.put(:receive_timeout, receive_timeout)
+    |> Req.new()
+  end
+
+  defp build_request(path, _opts) do
+    path
+    |> base_request_opts()
+    |> Req.new()
+  end
+
+  defp base_request_opts(path) do
     {url, api_key} = get_env()
 
-    req_opts = [
+    [
       base_url: url,
       url: path,
       headers: [
@@ -149,14 +163,6 @@ defmodule SmallSdk.Typesense do
         {"X-TYPESENSE-API-KEY", api_key}
       ]
     ]
-
-    req_opts =
-      case Keyword.fetch(opts, :receive_timeout) do
-        {:ok, receive_timeout} -> Keyword.put(req_opts, :receive_timeout, receive_timeout)
-        :error -> req_opts
-      end
-
-    Req.new(req_opts)
   end
 
   def handle_response({:ok, %{status: status, body: body}}) do

--- a/others/postmortem/2026-05-25-telegram-media-group-source-url-crash.md
+++ b/others/postmortem/2026-05-25-telegram-media-group-source-url-crash.md
@@ -1,0 +1,20 @@
+# Telegram Media Group Source URL Crash
+
+## What happened
+
+Saving a multi-image post could crash while sending the Telegram media group even though the images had already been downloaded successfully.
+
+## Root cause
+
+`SmallSdk.Telegram.send_media_group/2` assumed every item in `files` was a two-element tuple of `{file_name, content}`.
+The bot passes downloaded multi-image files as `{file_name, content, source_url}` so it can persist the original source URL for indexing.
+That mismatch caused a `FunctionClauseError` inside the reducer that builds the multipart request.
+
+## Fix applied
+
+Normalize media group file tuples inside `SmallSdk.Telegram.send_media_group/2` so both `{file_name, content}` and `{file_name, content, source_url}` are accepted.
+Add a regression test covering the three-element tuple shape used by downloaded X media.
+
+## What we learned
+
+Internal transport helpers should accept the metadata-rich tuple shapes already used by bot workflows, or normalize them at the boundary before pattern matching.

--- a/test/small_sdk/telegram_test.exs
+++ b/test/small_sdk/telegram_test.exs
@@ -1,0 +1,75 @@
+defmodule SmallSdk.TelegramTest do
+  use ExUnit.Case, async: false
+
+  alias SmallSdk.Telegram
+
+  defmodule TestAdapter do
+    @behaviour Tesla.Adapter
+
+    @impl Tesla.Adapter
+    def call(%Tesla.Env{} = env, _opts) do
+      send(Application.fetch_env!(:save_it, :test_pid), {:telegram_request, env})
+      {:ok, %Tesla.Env{env | status: 200, body: %{"ok" => true, "result" => []}}}
+    end
+  end
+
+  setup do
+    previous_token = Application.get_env(:save_it, :telegram_bot_token)
+    previous_test_pid = Application.get_env(:save_it, :test_pid)
+    previous_adapter = Application.get_env(:tesla, SmallSdk.Telegram)
+
+    Application.put_env(:save_it, :telegram_bot_token, "test-token")
+    Application.put_env(:save_it, :test_pid, self())
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: TestAdapter)
+
+    on_exit(fn ->
+      restore_env(:save_it, :telegram_bot_token, previous_token)
+      restore_env(:save_it, :test_pid, previous_test_pid)
+      restore_env(:tesla, SmallSdk.Telegram, previous_adapter)
+    end)
+
+    :ok
+  end
+
+  test "send_media_group accepts files with source urls" do
+    assert {:ok, []} =
+             Telegram.send_media_group(123, [
+               {"photo.jpg", {:file_content, <<1, 2, 3>>, "photo.jpg"}, "https://x.com/example"}
+             ])
+
+    assert_receive {:telegram_request, env}
+    assert env.url == "https://api.telegram.org/bottest-token/sendMediaGroup"
+
+    multipart = env.body
+    assert %Tesla.Multipart{} = multipart
+
+    assert multipart_field(multipart, "chat_id") == "123"
+
+    assert multipart_file_part(multipart, "media0").body == <<1, 2, 3>>
+    assert multipart_file_part(multipart, "media0").dispositions[:filename] == "photo.jpg"
+
+    media =
+      multipart
+      |> multipart_field("media")
+      |> Jason.decode!()
+
+    assert media == [%{"type" => "photo", "media" => "attach://media0"}]
+  end
+
+  defp multipart_field(multipart, name) do
+    multipart
+    |> multipart_part(name)
+    |> Map.fetch!(:body)
+  end
+
+  defp multipart_file_part(multipart, name) do
+    multipart_part(multipart, name)
+  end
+
+  defp multipart_part(multipart, name) do
+    Enum.find(multipart.parts, fn part -> part.dispositions[:name] == name end)
+  end
+
+  defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_env(app, key, value), do: Application.put_env(app, key, value)
+end


### PR DESCRIPTION
## Summary
- fix Telegram media group uploads to accept file tuples that include source URLs
- prevent Typesense requests from passing a nil receive timeout into Req/Finch
- improve `/search` relevance with calibrated vector thresholds and add search-response logging
- refactor the Typesense request builder to use Elixir pattern matching style
- add a regression test, changelog entries, and a postmortem for the media-group crash

## Testing
- mix test
- manual Typesense curl verification for `/search girl` and `/search dog`
