### PR TITLE
chore: split test and quality workflows

### DIFF
--- a/.agents/skills/acceptance-testing/SKILL.md
+++ b/.agents/skills/acceptance-testing/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the user asks for an acceptance testing flow based on Docker
 ## Commands
 
 ```bash
-mise run build-acceptance-test
+mise run build
 docker compose up -d cobalt-api typesense typelens
 docker compose --profile prod up --build save_it
 ```

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -1,0 +1,73 @@
+name: Elixir Quality Check
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Elixir
+        id: beam
+        uses: erlef/setup-beam@8d44588995e53ce789721e96227122a67826542d # v1.24.0
+        with:
+          elixir-version: "1.17"
+          otp-version: "27.0"
+
+      - name: Cache dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Restore Dialyzer PLT cache
+        id: plt_cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: plt-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            plt-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+          path: |
+            _build/dev/*.plt
+            _build/dev/*.plt.hash
+
+      - name: Install dependencies
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get
+
+      - name: Build Dialyzer PLTs
+        if: steps.plt_cache.outputs.cache-hit != 'true'
+        run: mix dialyzer --plt
+
+      - name: Save Dialyzer PLT cache
+        if: steps.plt_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: plt-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          path: |
+            _build/dev/*.plt
+            _build/dev/*.plt.hash
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Check compilation warnings
+        run: mix compile --warnings-as-errors
+
+      - name: Run Credo
+        run: mix credo --strict
+
+      - name: Run Dialyzer
+        run: mix dialyzer --format github --format dialyxir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Elixir CI
+name: Elixir Test
 
 on:
   push:
@@ -9,21 +9,23 @@ on:
       - main
 
 jobs:
-  checks:
+  test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Elixir
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@8d44588995e53ce789721e96227122a67826542d # v1.24.0
         with:
           elixir-version: "1.17"
           otp-version: "27.0"
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('mix.lock') }}
@@ -35,18 +37,6 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get
-
-      - name: Check formatting
-        run: mix format --check-formatted
-
-      - name: Check compilation warnings
-        run: mix compile --warnings-as-errors
-
-      - name: Run Credo
-        run: mix credo --strict
-
-      - name: Run Dialyzer
-        run: mix dialyzer
 
       - name: Run tests
         run: mix test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project uses [Calendar Versioning](https://calver.org/) with the `YYYY.
 ### Changed
 - Add request and result logging around Typesense photo searches to make empty `/search` responses easier to diagnose in production logs.
 - Tune `/search` image semantic retrieval to use a `0.785` vector distance cutoff and log top vector distances for easier relevance calibration.
-- Change `mix quality` to run formatter in check mode only, and split GitHub Actions checks into explicit formatter, compile, Credo, Dialyzer, and test steps within a single job.
+- Change `mix quality` to run formatter in check mode only, keep the main CI focused on tests, and move formatter, compile, Credo, and Dialyzer checks into a separate quality workflow that runs after code lands on `main`.
 
 ## [0.4.1] - 2026-05-24
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -22,5 +22,5 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 
 - Published image: `ghcr.io/thaddeusjiang/save_it`
 - Zeabur template image tag: `latest`
-- Local acceptance build check: `mise run build-acceptance-test`
+- Local acceptance build check: `mise run build`
 - Local Docker Compose stores Typesense data in the named volume `save_it_typesense_data`, so data is reused across worktrees on the same machine

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,31 @@ run = [
   "echo '✅ https://zeabur.com/templates/FTAONK'",
 ]
 
-[tasks.build-acceptance-test]
+[tasks.up]
+description = "Up containers"
+run = [
+    "docker compose up -d"
+]
+
+[tasks.dev]
+description = "Run dev"
+run = [
+    "iex -S mix run --no-halt"
+]
+
+[tasks.start]
+description = "Run start"
+run = [
+    "docker compose --profile prod up -d --build"
+]
+
+[tasks.stop]
+description = "Stop start"
+run = [
+    "docker compose --profile prod down"
+]
+
+[tasks.build]
 description = "Build the acceptance testing image locally"
 run = [
   "docker build -t save_it:ac .",


### PR DESCRIPTION
## Summary
- split the existing CI workflow into a pull-request test workflow and a post-merge quality workflow
- add convenient `mise` tasks for local container and app lifecycle commands
- update acceptance testing instructions, deployment docs, and changelog to match the new workflow

## Testing
- `mise trust`
- `mise install`
- `mix test`
