### PR TITLE
feat: Store original and download URLs for photos

### DIFF
--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -354,10 +354,10 @@ defmodule SaveIt.Bot do
         handle_hls_download(chat_id, progress_message_id, url, m3u8_url)
 
       {:ok, purge_url, download_urls} ->
-        handle_multi_file_download(chat_id, progress_message_id, purge_url, download_urls)
+        handle_multi_file_download(chat_id, progress_message_id, url, purge_url, download_urls)
 
       {:ok, download_url} ->
-        handle_single_file_download(chat_id, progress_message_id, download_url)
+        handle_single_file_download(chat_id, progress_message_id, url, download_url)
 
       {:error, _} ->
         update_message(chat_id, progress_message_id, "💔 Failed to get download URL.")
@@ -387,26 +387,44 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp handle_multi_file_download(chat_id, progress_message_id, purge_url, download_urls) do
-    case FileHelper.get_downloaded_files(download_urls) do
+  defp handle_multi_file_download(
+         chat_id,
+         progress_message_id,
+         original_url,
+         purge_url,
+         download_urls
+       ) do
+    case FileHelper.get_downloaded_files(purge_url) do
       nil ->
-        download_and_store_files(chat_id, progress_message_id, purge_url, download_urls)
+        download_and_store_files(
+          chat_id,
+          progress_message_id,
+          original_url,
+          purge_url,
+          download_urls
+        )
 
       downloaded_files ->
         update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
-        bot_send_filenames(chat_id, downloaded_files)
+        bot_send_filenames(chat_id, downloaded_files, source_url: original_url)
         delete_message(chat_id, progress_message_id)
         :ok
     end
   end
 
-  defp download_and_store_files(chat_id, progress_message_id, purge_url, download_urls) do
+  defp download_and_store_files(
+         chat_id,
+         progress_message_id,
+         original_url,
+         purge_url,
+         download_urls
+       ) do
     update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..1))
 
     case WebDownloader.download_files(download_urls) do
       {:ok, files} ->
         update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
-        bot_send_files(chat_id, files)
+        bot_send_files(chat_id, files, source_url: original_url)
         delete_message(chat_id, progress_message_id)
         FileHelper.write_folder(purge_url, files)
         GoogleDrive.upload_files(chat_id, files)
@@ -418,16 +436,17 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp handle_single_file_download(chat_id, progress_message_id, download_url) do
+  defp handle_single_file_download(chat_id, progress_message_id, original_url, download_url) do
     case FileHelper.get_downloaded_file(download_url) do
       nil ->
-        download_and_store_file(chat_id, progress_message_id, download_url)
+        download_and_store_file(chat_id, progress_message_id, original_url, download_url)
 
       downloaded_file ->
         update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
 
         bot_send_file(chat_id, downloaded_file, {:file, downloaded_file},
-          source_url: download_url
+          source_url: original_url,
+          download_url: download_url
         )
 
         delete_message(chat_id, progress_message_id)
@@ -435,18 +454,19 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp download_and_store_file(chat_id, progress_message_id, download_url) do
+  defp download_and_store_file(chat_id, progress_message_id, original_url, download_url) do
     update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..1))
 
     case WebDownloader.download_file(download_url) do
-      {:ok, file_name, file_content, source_url} ->
+      {:ok, file_name, file_content, _source_url} ->
         update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
 
         bot_send_file(
           chat_id,
           file_name,
           {:file_content, file_content, file_name},
-          source_url: source_url
+          source_url: original_url,
+          download_url: download_url
         )
 
         finalize_single_download(
@@ -492,34 +512,41 @@ defmodule SaveIt.Bot do
     ExGram.delete_message(chat_id, message_id)
   end
 
-  defp bot_send_files(chat_id, files) do
+  defp bot_send_files(chat_id, files, opts) do
+    source_url = Keyword.get(opts, :source_url)
+
     if all_images?(files) and length(files) > 1 do
       bot_send_media_group(
         chat_id,
-        Enum.map(files, fn {file_name, file_content, source_url} ->
-          {file_name, {:file_content, file_content, file_name}, source_url}
+        Enum.map(files, fn {file_name, file_content, download_url} ->
+          {file_name, {:file_content, file_content, file_name}, source_url, download_url}
         end)
       )
     else
-      Enum.each(files, fn {file_name, file_content, source_url} ->
+      Enum.each(files, fn {file_name, file_content, download_url} ->
         bot_send_file(
           chat_id,
           file_name,
           {:file_content, file_content, file_name},
-          source_url: source_url
+          source_url: source_url,
+          download_url: download_url
         )
       end)
     end
   end
 
-  defp bot_send_filenames(chat_id, filenames) do
+  defp bot_send_filenames(chat_id, filenames, opts) do
+    source_url = Keyword.get(opts, :source_url)
+
     if all_images?(filenames) and length(filenames) > 1 do
       bot_send_media_group(
         chat_id,
-        Enum.map(filenames, fn filename -> {filename, {:file, filename}} end)
+        Enum.map(filenames, fn filename -> {filename, {:file, filename}, source_url} end)
       )
     else
-      Enum.each(filenames, fn filename -> bot_send_file(chat_id, filename, {:file, filename}) end)
+      Enum.each(filenames, fn filename ->
+        bot_send_file(chat_id, filename, {:file, filename}, source_url: source_url)
+      end)
     end
   end
 
@@ -528,6 +555,19 @@ defmodule SaveIt.Bot do
       {:ok, messages} ->
         Enum.zip(files, messages)
         |> Enum.each(fn
+          {{_file_name, content, source_url, download_url}, msg} ->
+            file_id = get_file_id(msg)
+            image_base64 = encode_file_content(content)
+
+            PhotoService.create_photo!(%{
+              image: image_base64,
+              caption: "",
+              file_id: file_id,
+              url: source_url,
+              download_url: download_url,
+              belongs_to_id: chat_id
+            })
+
           {{_file_name, content, source_url}, msg} ->
             file_id = get_file_id(msg)
             image_base64 = encode_file_content(content)
@@ -556,6 +596,12 @@ defmodule SaveIt.Bot do
         Logger.error("Failed to send media group: #{inspect(reason)}")
 
         Enum.each(files, fn
+          {file_name, content, source_url, download_url} ->
+            bot_send_file(chat_id, file_name, content,
+              source_url: source_url,
+              download_url: download_url
+            )
+
           {file_name, content, source_url} ->
             bot_send_file(chat_id, file_name, content, source_url: source_url)
 
@@ -574,6 +620,7 @@ defmodule SaveIt.Bot do
 
     caption = Keyword.get(opts, :caption, "")
     source_url = Keyword.get(opts, :source_url)
+    download_url = Keyword.get(opts, :download_url)
 
     case file_extension(file_name) do
       ext when ext in [".png", ".jpg", ".jpeg"] ->
@@ -589,6 +636,7 @@ defmodule SaveIt.Bot do
           caption: caption,
           file_id: file_id,
           url: source_url,
+          download_url: download_url,
           belongs_to_id: chat_id
         })
 

--- a/lib/save_it/google_drive.ex
+++ b/lib/save_it/google_drive.ex
@@ -51,8 +51,12 @@ defmodule SaveIt.GoogleDrive do
     access_token = FileHelper.get_google_access_token(chat_id)
     folder_id = FileHelper.get_google_drive_folder_id(chat_id)
 
-    Enum.map(files, fn {file_name, file_content} ->
-      upload_file(file_name, file_content, folder_id, access_token)
+    Enum.map(files, fn
+      {file_name, file_content} ->
+        upload_file(file_name, file_content, folder_id, access_token)
+
+      {file_name, file_content, _source_url} ->
+        upload_file(file_name, file_content, folder_id, access_token)
     end)
   end
 

--- a/lib/save_it/photo_service.ex
+++ b/lib/save_it/photo_service.ex
@@ -4,7 +4,7 @@ defmodule SaveIt.PhotoService do
   require Logger
   alias SmallSdk.Typesense
 
-  import SaveIt.SmallHelper.UrlHelper, only: [validate_url!: 1]
+  import SaveIt.SmallHelper.UrlHelper, only: [normalize_optional_url: 1, validate_url!: 1]
 
   def create_photo!(
         %{
@@ -13,6 +13,7 @@ defmodule SaveIt.PhotoService do
       ) do
     photo_create_input =
       photo_params
+      |> normalize_photo_urls()
       |> Map.put(:belongs_to_id, Integer.to_string(belongs_to_id))
       |> Map.put(:inserted_at, DateTime.utc_now() |> DateTime.to_unix())
 
@@ -174,5 +175,21 @@ defmodule SaveIt.PhotoService do
           results: results
         })
     )
+  end
+
+  defp normalize_photo_urls(photo_params) do
+    [:url, :download_url]
+    |> Enum.reduce(photo_params, fn field, acc ->
+      case Map.fetch(acc, field) do
+        {:ok, url} ->
+          case normalize_optional_url(url) do
+            nil -> Map.delete(acc, field)
+            normalized_url -> Map.put(acc, field, normalized_url)
+          end
+
+        :error ->
+          acc
+      end
+    end)
   end
 end

--- a/lib/save_it/small_helper/url_helper.ex
+++ b/lib/save_it/small_helper/url_helper.ex
@@ -34,6 +34,18 @@ defmodule SaveIt.SmallHelper.UrlHelper do
     end
   end
 
+  def normalize_optional_url(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: scheme, host: host} when scheme in ["http", "https"] and is_binary(host) ->
+        url
+
+      _ ->
+        nil
+    end
+  end
+
+  def normalize_optional_url(_), do: nil
+
   def direct_media_url?(url) when is_binary(url) do
     case URI.parse(url) do
       %URI{scheme: scheme, host: host} = uri

--- a/lib/small_sdk/telegram.ex
+++ b/lib/small_sdk/telegram.ex
@@ -54,6 +54,9 @@ defmodule SmallSdk.Telegram do
     end
   end
 
+  defp media_group_file_parts({file_name, content, _source_url, _download_url}),
+    do: {file_name, content}
+
   defp media_group_file_parts({file_name, content, _source_url}), do: {file_name, content}
   defp media_group_file_parts({file_name, content}), do: {file_name, content}
 

--- a/priv/typesense/migrations/20260525000000_add_download_url_to_photos.exs
+++ b/priv/typesense/migrations/20260525000000_add_download_url_to_photos.exs
@@ -1,0 +1,55 @@
+defmodule SaveIt.Typesense.Migrations.AddDownloadUrlToPhotos20260525000000 do
+  @moduledoc false
+
+  alias SaveIt.TypesenseMigration
+  alias SmallSdk.Typesense
+
+  @collection_name "photos"
+
+  def version, do: "20260525000000"
+  def name, do: "add_download_url_to_photos"
+
+  def up do
+    case TypesenseMigration.field(@collection_name, "download_url") do
+      nil ->
+        Typesense.update_collection!(@collection_name, %{
+          "fields" => [
+            %{"name" => "download_url", "type" => "string", "optional" => true}
+          ]
+        })
+
+      %{"optional" => true} ->
+        :ok
+
+      _field ->
+        Typesense.update_collection!(@collection_name, %{
+          "fields" => [
+            %{"name" => "download_url", "drop" => true}
+          ]
+        })
+
+        Typesense.update_collection!(@collection_name, %{
+          "fields" => [
+            %{"name" => "download_url", "type" => "string", "optional" => true}
+          ]
+        })
+    end
+  end
+
+  def down do
+    if TypesenseMigration.has_field?(@collection_name, "download_url") do
+      Typesense.update_collection!(@collection_name, %{
+        "fields" => [
+          %{"name" => "download_url", "drop" => true}
+        ]
+      })
+    end
+  end
+
+  def applied? do
+    case TypesenseMigration.field(@collection_name, "download_url") do
+      %{"optional" => true} -> true
+      _ -> false
+    end
+  end
+end

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -1,0 +1,364 @@
+defmodule SaveIt.BotTest do
+  use ExUnit.Case, async: false
+
+  alias ExGram.Adapter.Test, as: ExGramTestAdapter
+  alias SaveIt.Bot
+  alias SaveIt.FileHelper
+
+  setup do
+    server = start_supervised!({__MODULE__.TestHttpServer, test_pid: self()})
+    base_url = "http://127.0.0.1:#{__MODULE__.TestHttpServer.port(server)}"
+
+    previous_ex_gram = Application.get_all_env(:ex_gram)
+    previous_save_it = Application.get_all_env(:save_it)
+    previous_small_sdk_telegram = Application.get_env(:tesla, SmallSdk.Telegram)
+
+    Application.put_env(:ex_gram, :adapter, ExGram.Adapter.Test)
+    Application.put_env(:ex_gram, :token, "test-token")
+    Application.put_env(:save_it, :cobalt_api_url, base_url)
+    Application.put_env(:save_it, :typesense_url, base_url)
+    Application.put_env(:save_it, :typesense_api_key, "test-typesense-key")
+
+    if Process.whereis(ExGram.Adapter.Test) do
+      ExGramTestAdapter.clean()
+    else
+      start_supervised!(%{
+        id: ExGram.Adapter.Test,
+        start: {ExGram.Adapter.Test, :start_link, [[]]}
+      })
+    end
+
+    ExGramTestAdapter.backdoor_request("/sendMessage", %{message_id: 10})
+    ExGramTestAdapter.backdoor_request("/editMessageText", %{message_id: 10})
+    ExGramTestAdapter.backdoor_request("/deleteMessage", true)
+
+    ExGramTestAdapter.backdoor_request("/sendPhoto", %{
+      message_id: 20,
+      photo: [%{file_id: "telegram-photo-file-id"}]
+    })
+
+    on_exit(fn ->
+      if Process.whereis(ExGram.Adapter.Test) do
+        ExGramTestAdapter.clean()
+      end
+
+      restore_env(:tesla, SmallSdk.Telegram, previous_small_sdk_telegram)
+      restore_env(:ex_gram, previous_ex_gram)
+      restore_env(:save_it, previous_save_it)
+    end)
+
+    %{base_url: base_url}
+  end
+
+  test "stores the original user-sent url when indexing a downloaded photo", %{base_url: base_url} do
+    original_url = "https://x.com/example/status/1?utm_source=telegram"
+    download_url = base_url <> "/downloaded/photo.jpg"
+    cached_file_name = "bot-original-url-test.jpg"
+    cached_file_content = <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70>>
+
+    FileHelper.write_file(cached_file_name, cached_file_content, download_url)
+
+    on_exit(fn ->
+      cleanup_cached_file(download_url, cached_file_name)
+    end)
+
+    message = %{
+      chat: %{id: 12_345},
+      message_id: 99
+    }
+
+    assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => "https://x.com/example/status/1"}
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    assert document["file_id"] == "telegram-photo-file-id"
+    assert document["belongs_to_id"] == "12345"
+  end
+
+  test "stores the original user-sent url for every photo in a multi-image download", _context do
+    original_url = "https://x.com/JennerItGirls/status/2057529104535023815?s=20"
+    purge_url = "https://x.com/JennerItGirls/status/2057529104535023815"
+
+    cleanup_cached_folder(purge_url)
+
+    on_exit(fn ->
+      cleanup_cached_folder(purge_url)
+    end)
+
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramMediaGroupAdapter)
+
+    message = %{
+      chat: %{id: 12_345},
+      message_id: 100
+    }
+
+    assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+
+    assert Jason.decode!(cobalt_body) == %{
+             "url" => "https://x.com/JennerItGirls/status/2057529104535023815"
+           }
+
+    assert_receive {:telegram_media_group_request, _conn}
+
+    documents =
+      Enum.map(1..4, fn _ ->
+        assert_receive {:test_http_request, :post, "/collections/photos/documents",
+                        typesense_body}
+
+        Jason.decode!(typesense_body)
+      end)
+
+    assert Enum.map(documents, & &1["url"]) == List.duplicate(original_url, 4)
+
+    assert Enum.map(documents, & &1["download_url"]) |> Enum.sort() ==
+             [
+               "#{base_test_server_url()}/downloaded/photo-1.jpg",
+               "#{base_test_server_url()}/downloaded/photo-2.jpg",
+               "#{base_test_server_url()}/downloaded/photo-3.jpg",
+               "#{base_test_server_url()}/downloaded/photo-4.jpg"
+             ]
+             |> Enum.sort()
+
+    assert Enum.map(documents, & &1["file_id"]) == [
+             "group-file-1",
+             "group-file-2",
+             "group-file-3",
+             "group-file-4"
+           ]
+  end
+
+  defp cleanup_cached_file(download_url, cached_file_name) do
+    hashed_url = :crypto.hash(:sha256, download_url) |> Base.url_encode64(padding: false)
+    url_cache_path = Path.join(["./data/storage/urls", hashed_url])
+    file_path = Path.join(["./data/storage/files", cached_file_name])
+
+    File.rm(url_cache_path)
+    File.rm(file_path)
+  end
+
+  defp base_test_server_url do
+    Application.fetch_env!(:save_it, :typesense_url)
+  end
+
+  defp cleanup_cached_folder(cache_key_url) do
+    hashed_url = :crypto.hash(:sha256, cache_key_url) |> Base.url_encode64(padding: false)
+    url_cache_path = Path.join(["./data/storage/urls", hashed_url])
+    files_dir_path = Path.join(["./data/storage/files", hashed_url])
+
+    File.rm(url_cache_path)
+    File.rm_rf(files_dir_path)
+  end
+
+  defp restore_env(app, env) do
+    Application.get_all_env(app)
+    |> Keyword.keys()
+    |> Enum.each(&Application.delete_env(app, &1))
+
+    Enum.each(env, fn {key, value} ->
+      Application.put_env(app, key, value)
+    end)
+  end
+
+  defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_env(app, key, value), do: Application.put_env(app, key, value)
+
+  defmodule TelegramMediaGroupAdapter do
+    @behaviour Tesla.Adapter
+
+    @impl Tesla.Adapter
+    def call(%Tesla.Env{} = env, _opts) do
+      send(self(), {:telegram_media_group_request, env})
+
+      {:ok,
+       %Tesla.Env{
+         env
+         | status: 200,
+           body: %{
+             "ok" => true,
+             "result" => [
+               %{"photo" => [%{"file_id" => "group-file-1"}]},
+               %{"photo" => [%{"file_id" => "group-file-2"}]},
+               %{"photo" => [%{"file_id" => "group-file-3"}]},
+               %{"photo" => [%{"file_id" => "group-file-4"}]}
+             ]
+           }
+       }}
+    end
+  end
+
+  defmodule TestHttpServer do
+    use GenServer
+
+    defstruct [:listen_socket, :port, :test_pid, :acceptor_pid]
+
+    def start_link(opts) do
+      GenServer.start_link(__MODULE__, opts)
+    end
+
+    def port(server) do
+      GenServer.call(server, :port)
+    end
+
+    def init(opts) do
+      {:ok, listen_socket} =
+        :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+      {:ok, port} = :inet.port(listen_socket)
+      test_pid = Keyword.fetch!(opts, :test_pid)
+
+      state = %__MODULE__{
+        listen_socket: listen_socket,
+        port: port,
+        test_pid: test_pid
+      }
+
+      {:ok, acceptor_pid} =
+        Task.start_link(fn ->
+          accept_loop(listen_socket, test_pid, port)
+        end)
+
+      {:ok, %{state | acceptor_pid: acceptor_pid}}
+    end
+
+    def handle_call(:port, _from, %{port: port} = state) do
+      {:reply, port, state}
+    end
+
+    def terminate(_reason, %{listen_socket: listen_socket, acceptor_pid: acceptor_pid}) do
+      if is_pid(acceptor_pid) do
+        Process.exit(acceptor_pid, :normal)
+      end
+
+      :gen_tcp.close(listen_socket)
+      :ok
+    end
+
+    defp accept_loop(listen_socket, test_pid, port) do
+      case :gen_tcp.accept(listen_socket) do
+        {:ok, socket} ->
+          handle_socket(socket, test_pid, port)
+          accept_loop(listen_socket, test_pid, port)
+
+        {:error, :closed} ->
+          :ok
+      end
+    end
+
+    defp handle_socket(socket, test_pid, port) do
+      {method, path, body} = read_http_request(socket)
+      send(test_pid, {:test_http_request, method, path, body})
+      :gen_tcp.send(socket, response_for(path, port, body))
+      :gen_tcp.close(socket)
+    end
+
+    defp response_for("/", port, body) do
+      case Jason.decode!(body) do
+        %{"url" => "https://x.com/example/status/1"} ->
+          json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg"})
+
+        %{"url" => "https://x.com/JennerItGirls/status/2057529104535023815"} ->
+          json_response(%{
+            "status" => "picker",
+            "picker" => [
+              %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-1.jpg"},
+              %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-2.jpg"},
+              %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-3.jpg"},
+              %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-4.jpg"}
+            ]
+          })
+
+        unexpected ->
+          raise "Unexpected cobalt request body: #{inspect(unexpected)}"
+      end
+    end
+
+    defp response_for("/collections/photos/documents", _port, _body) do
+      json_response(%{"id" => "typesense-photo-id"})
+    end
+
+    defp response_for("/downloaded/" <> _file_name, _port, _body) do
+      jpeg = <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70>>
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: image/jpeg\r
+      content-length: #{byte_size(jpeg)}\r
+      connection: close\r
+      \r
+      #{jpeg}
+      """
+    end
+
+    defp response_for(_path, _port, _body) do
+      """
+      HTTP/1.1 404 Not Found\r
+      content-length: 0\r
+      connection: close\r
+      \r
+      """
+    end
+
+    defp json_response(body) do
+      encoded_body = Jason.encode!(body)
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: application/json\r
+      content-length: #{byte_size(encoded_body)}\r
+      connection: close\r
+      \r
+      #{encoded_body}
+      """
+    end
+
+    defp read_http_request(socket) do
+      {:ok, initial_data} = :gen_tcp.recv(socket, 0, 5_000)
+      {header_data, body_prefix} = split_headers(initial_data)
+      [request_line | header_lines] = String.split(header_data, "\r\n", trim: true)
+      [method, path, _http_version] = String.split(request_line, " ")
+
+      content_length =
+        header_lines
+        |> Enum.find_value(0, fn line ->
+          case String.split(line, ":", parts: 2) do
+            [name, value] ->
+              if String.downcase(name) == "content-length" do
+                value |> String.trim() |> String.to_integer()
+              end
+
+            _ ->
+              nil
+          end
+        end)
+
+      body = read_body(socket, body_prefix, content_length)
+
+      {String.downcase(method) |> String.to_atom(), path, body}
+    end
+
+    defp split_headers(data) do
+      [headers, body] = :binary.split(data, "\r\n\r\n")
+      {headers, body}
+    end
+
+    defp read_body(_socket, body_prefix, content_length)
+         when byte_size(body_prefix) >= content_length do
+      binary_part(body_prefix, 0, content_length)
+    end
+
+    defp read_body(socket, body_prefix, content_length) do
+      remaining = content_length - byte_size(body_prefix)
+      {:ok, body_suffix} = :gen_tcp.recv(socket, remaining, 5_000)
+      body_prefix <> body_suffix
+    end
+  end
+end

--- a/test/url_helper_test.exs
+++ b/test/url_helper_test.exs
@@ -3,6 +3,17 @@ defmodule SaveIt.SmallHelper.UrlHelperTest do
 
   alias SaveIt.SmallHelper.UrlHelper
 
+  test "normalize_optional_url/1 keeps valid http urls" do
+    assert UrlHelper.normalize_optional_url("https://example.com/photo.jpg") ==
+             "https://example.com/photo.jpg"
+  end
+
+  test "normalize_optional_url/1 returns nil for non-url values" do
+    assert UrlHelper.normalize_optional_url(nil) == nil
+    assert UrlHelper.normalize_optional_url("not-a-url") == nil
+    assert UrlHelper.normalize_optional_url({:file_content, <<1, 2, 3>>, "photo.jpg"}) == nil
+  end
+
   test "direct_media_url?/1 returns true for media extension in path" do
     assert UrlHelper.direct_media_url?(
              "https://docs.expo.dev/static/videos/tutorial/01-navigating-between-screens.mp4"


### PR DESCRIPTION
## Summary
- store the user-sent source URL on photo records for both single-image and multi-image downloads
- add an optional `download_url` field to photos and persist the resolved media URL when available
- cover single-image and multi-image indexing flows with regression tests

## Migration
- run `mix ts.migrate`

## Testing
- mix test test/bot_test.exs test/url_helper_test.exs test/small_sdk/telegram_test.exs
- mix test
