### PR TITLE
Refactor download flow data structures

### DIFF
--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -5,6 +5,8 @@ defmodule SaveIt.Bot do
 
   import SaveIt.SmallHelper.UrlHelper, only: [direct_media_url?: 1]
 
+  alias SaveIt.DownloadContext
+  alias SaveIt.DownloadedFile
   alias SaveIt.FileHelper
   alias SaveIt.GoogleDrive
   alias SaveIt.GoogleOAuth2DeviceFlow
@@ -347,152 +349,121 @@ defmodule SaveIt.Bot do
 
   defp process_url(chat_id, url) do
     {:ok, progress_message} = send_message(chat_id, Enum.at(@progress, 0))
-    progress_message_id = progress_message.message_id
+
+    context = %DownloadContext{
+      chat_id: chat_id,
+      progress_message_id: progress_message.message_id,
+      original_url: url
+    }
 
     case get_download_url(url) do
       {:ok, m3u8_url, :hls} ->
-        handle_hls_download(chat_id, progress_message_id, url, m3u8_url)
+        handle_hls_download(%{context | cache_url: url}, m3u8_url)
 
       {:ok, purge_url, download_urls} ->
-        handle_multi_file_download(chat_id, progress_message_id, url, purge_url, download_urls)
+        handle_multi_file_download(%{context | purge_url: purge_url}, download_urls)
 
       {:ok, download_url} ->
-        handle_single_file_download(chat_id, progress_message_id, url, download_url)
+        handle_single_file_download(%{
+          context
+          | download_url: download_url,
+            cache_url: download_url
+        })
 
       {:error, _} ->
-        update_message(chat_id, progress_message_id, "💔 Failed to get download URL.")
+        update_message(chat_id, context.progress_message_id, "💔 Failed to get download URL.")
         :error
     end
   end
 
-  defp handle_hls_download(chat_id, progress_message_id, original_url, m3u8_url) do
-    update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..1))
+  defp handle_hls_download(%DownloadContext{} = context, m3u8_url) do
+    update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..1))
 
     case HlsDownloader.download(m3u8_url) do
-      {:ok, file_name, file_content} ->
-        update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
-        bot_send_file(chat_id, file_name, {:file_content, file_content, file_name})
-
-        finalize_single_download(
-          chat_id,
-          progress_message_id,
-          file_name,
-          file_content,
-          original_url
-        )
+      {:ok, %DownloadedFile{} = file} ->
+        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+        bot_send_downloaded_file(context.chat_id, file)
+        finalize_single_download(context, file)
 
       {:error, _reason} ->
-        update_message(chat_id, progress_message_id, "💔 Failed downloading HLS video.")
+        update_message(
+          context.chat_id,
+          context.progress_message_id,
+          "💔 Failed downloading HLS video."
+        )
+
         :error
     end
   end
 
-  defp handle_multi_file_download(
-         chat_id,
-         progress_message_id,
-         original_url,
-         purge_url,
-         download_urls
-       ) do
-    case FileHelper.get_downloaded_files(purge_url) do
+  defp handle_multi_file_download(%DownloadContext{} = context, download_urls) do
+    case FileHelper.get_downloaded_files(context.purge_url) do
       nil ->
-        download_and_store_files(
-          chat_id,
-          progress_message_id,
-          original_url,
-          purge_url,
-          download_urls
-        )
+        download_and_store_files(context, download_urls)
 
       downloaded_files ->
-        update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
-        bot_send_filenames(chat_id, downloaded_files, source_url: original_url)
-        delete_message(chat_id, progress_message_id)
+        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+        bot_send_filenames(context.chat_id, downloaded_files, source_url: context.original_url)
+        delete_message(context.chat_id, context.progress_message_id)
         :ok
     end
   end
 
-  defp download_and_store_files(
-         chat_id,
-         progress_message_id,
-         original_url,
-         purge_url,
-         download_urls
-       ) do
-    update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..1))
+  defp download_and_store_files(%DownloadContext{} = context, download_urls) do
+    update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..1))
 
     case WebDownloader.download_files(download_urls) do
       {:ok, files} ->
-        update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
-        bot_send_files(chat_id, files, source_url: original_url)
-        delete_message(chat_id, progress_message_id)
-        FileHelper.write_folder(purge_url, files)
-        GoogleDrive.upload_files(chat_id, files)
+        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+        bot_send_files(context.chat_id, files, source_url: context.original_url)
+        delete_message(context.chat_id, context.progress_message_id)
+        FileHelper.write_folder(context.purge_url, files)
+        GoogleDrive.upload_files(context.chat_id, files)
         :ok
 
       _ ->
-        update_message(chat_id, progress_message_id, "💔 Failed downloading file.")
+        update_message(context.chat_id, context.progress_message_id, "💔 Failed downloading file.")
         :error
     end
   end
 
-  defp handle_single_file_download(chat_id, progress_message_id, original_url, download_url) do
-    case FileHelper.get_downloaded_file(download_url) do
+  defp handle_single_file_download(%DownloadContext{} = context) do
+    case FileHelper.get_downloaded_file(context.download_url) do
       nil ->
-        download_and_store_file(chat_id, progress_message_id, original_url, download_url)
+        download_and_store_file(context)
 
       downloaded_file ->
-        update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
+        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
 
-        bot_send_file(chat_id, downloaded_file, {:file, downloaded_file},
-          source_url: original_url,
-          download_url: download_url
+        bot_send_file(context.chat_id, downloaded_file, {:file, downloaded_file},
+          source_url: context.original_url,
+          download_url: context.download_url
         )
 
-        delete_message(chat_id, progress_message_id)
+        delete_message(context.chat_id, context.progress_message_id)
         :ok
     end
   end
 
-  defp download_and_store_file(chat_id, progress_message_id, original_url, download_url) do
-    update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..1))
+  defp download_and_store_file(%DownloadContext{} = context) do
+    update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..1))
 
-    case WebDownloader.download_file(download_url) do
-      {:ok, file_name, file_content, _source_url} ->
-        update_message(chat_id, progress_message_id, Enum.slice(@progress, 0..2))
-
-        bot_send_file(
-          chat_id,
-          file_name,
-          {:file_content, file_content, file_name},
-          source_url: original_url,
-          download_url: download_url
-        )
-
-        finalize_single_download(
-          chat_id,
-          progress_message_id,
-          file_name,
-          file_content,
-          download_url
-        )
+    case WebDownloader.download_file(context.download_url) do
+      {:ok, %DownloadedFile{} = file} ->
+        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+        bot_send_downloaded_file(context.chat_id, file, source_url: context.original_url)
+        finalize_single_download(context, file)
 
       _ ->
-        update_message(chat_id, progress_message_id, "💔 Failed downloading file.")
+        update_message(context.chat_id, context.progress_message_id, "💔 Failed downloading file.")
         :error
     end
   end
 
-  defp finalize_single_download(
-         chat_id,
-         progress_message_id,
-         file_name,
-         file_content,
-         download_url
-       ) do
-    delete_message(chat_id, progress_message_id)
-    FileHelper.write_file(file_name, file_content, download_url)
-    GoogleDrive.upload_file_content(chat_id, file_content, file_name)
+  defp finalize_single_download(%DownloadContext{} = context, %DownloadedFile{} = file) do
+    delete_message(context.chat_id, context.progress_message_id)
+    FileHelper.write_file(file.file_name, file.file_content, context.cache_url)
+    GoogleDrive.upload_file_content(context.chat_id, file.file_content, file.file_name)
     :ok
   end
 
@@ -518,21 +489,25 @@ defmodule SaveIt.Bot do
     if all_images?(files) and length(files) > 1 do
       bot_send_media_group(
         chat_id,
-        Enum.map(files, fn {file_name, file_content, download_url} ->
-          {file_name, {:file_content, file_content, file_name}, source_url, download_url}
+        Enum.map(files, fn %DownloadedFile{} = file ->
+          {file.file_name, {:file_content, file.file_content, file.file_name}, source_url,
+           file.download_url}
         end)
       )
     else
-      Enum.each(files, fn {file_name, file_content, download_url} ->
-        bot_send_file(
-          chat_id,
-          file_name,
-          {:file_content, file_content, file_name},
-          source_url: source_url,
-          download_url: download_url
-        )
+      Enum.each(files, fn %DownloadedFile{} = file ->
+        bot_send_downloaded_file(chat_id, file, source_url: source_url)
       end)
     end
+  end
+
+  defp bot_send_downloaded_file(chat_id, %DownloadedFile{} = file, opts \\ []) do
+    bot_send_file(
+      chat_id,
+      file.file_name,
+      {:file_content, file.file_content, file.file_name},
+      Keyword.put_new(opts, :download_url, file.download_url)
+    )
   end
 
   defp bot_send_filenames(chat_id, filenames, opts) do
@@ -657,6 +632,9 @@ defmodule SaveIt.Bot do
 
   defp all_images?(files) when is_list(files) do
     Enum.all?(files, fn
+      %DownloadedFile{file_name: file_name} ->
+        image_file?(file_name)
+
       {file_name, _file_content, _source_url} ->
         image_file?(file_name)
 

--- a/lib/save_it/download_context.ex
+++ b/lib/save_it/download_context.ex
@@ -1,0 +1,6 @@
+defmodule SaveIt.DownloadContext do
+  @moduledoc false
+
+  @enforce_keys [:chat_id, :progress_message_id, :original_url]
+  defstruct [:chat_id, :progress_message_id, :original_url, :download_url, :purge_url, :cache_url]
+end

--- a/lib/save_it/downloaded_file.ex
+++ b/lib/save_it/downloaded_file.ex
@@ -1,0 +1,6 @@
+defmodule SaveIt.DownloadedFile do
+  @moduledoc false
+
+  @enforce_keys [:file_name, :file_content]
+  defstruct [:file_name, :file_content, :download_url]
+end

--- a/lib/save_it/file_helper.ex
+++ b/lib/save_it/file_helper.ex
@@ -3,6 +3,8 @@ defmodule SaveIt.FileHelper do
 
   require Logger
 
+  alias SaveIt.DownloadedFile
+
   @files_dir "./data/storage/files"
   @urls_dir "./data/storage/urls"
 
@@ -61,6 +63,9 @@ defmodule SaveIt.FileHelper do
     hashed_url = :crypto.hash(:sha256, original_url) |> Base.url_encode64(padding: false)
 
     Enum.each(files, fn
+      %DownloadedFile{file_name: file_name, file_content: file_content} ->
+        write_file_to_disk(Path.join(@files_dir, hashed_url), file_name, file_content)
+
       {file_name, file_content} ->
         write_file_to_disk(Path.join(@files_dir, hashed_url), file_name, file_content)
 
@@ -71,7 +76,11 @@ defmodule SaveIt.FileHelper do
     write_file_to_disk(
       @urls_dir,
       hashed_url,
-      Enum.map_join(files, "\n", &elem(&1, 0))
+      Enum.map_join(files, "\n", fn
+        %DownloadedFile{file_name: file_name} -> file_name
+        {file_name, _file_content} -> file_name
+        {file_name, _file_content, _source_url} -> file_name
+      end)
     )
   end
 

--- a/lib/save_it/google_drive.ex
+++ b/lib/save_it/google_drive.ex
@@ -7,6 +7,7 @@ defmodule SaveIt.GoogleDrive do
   - Move the raw API client into `SmallSdk`.
   - Support browsing and selecting folders.
   """
+  alias SaveIt.DownloadedFile
   alias SaveIt.FileHelper
   require Logger
   use Tesla
@@ -52,10 +53,7 @@ defmodule SaveIt.GoogleDrive do
     folder_id = FileHelper.get_google_drive_folder_id(chat_id)
 
     Enum.map(files, fn
-      {file_name, file_content} ->
-        upload_file(file_name, file_content, folder_id, access_token)
-
-      {file_name, file_content, _source_url} ->
+      %DownloadedFile{file_name: file_name, file_content: file_content} ->
         upload_file(file_name, file_content, folder_id, access_token)
     end)
   end

--- a/lib/save_it/photo_service.ex
+++ b/lib/save_it/photo_service.ex
@@ -178,18 +178,18 @@ defmodule SaveIt.PhotoService do
   end
 
   defp normalize_photo_urls(photo_params) do
-    [:url, :download_url]
-    |> Enum.reduce(photo_params, fn field, acc ->
-      case Map.fetch(acc, field) do
-        {:ok, url} ->
-          case normalize_optional_url(url) do
-            nil -> Map.delete(acc, field)
-            normalized_url -> Map.put(acc, field, normalized_url)
-          end
-
-        :error ->
-          acc
-      end
-    end)
+    Enum.reduce([:url, :download_url], photo_params, &normalize_photo_url_field/2)
   end
+
+  defp normalize_photo_url_field(field, acc) do
+    case Map.fetch(acc, field) do
+      {:ok, url} -> put_normalized_photo_url(acc, field, normalize_optional_url(url))
+      :error -> acc
+    end
+  end
+
+  defp put_normalized_photo_url(acc, field, nil), do: Map.delete(acc, field)
+
+  defp put_normalized_photo_url(acc, field, normalized_url),
+    do: Map.put(acc, field, normalized_url)
 end

--- a/lib/small_sdk/hls_downloader.ex
+++ b/lib/small_sdk/hls_downloader.ex
@@ -3,6 +3,8 @@ defmodule SmallSdk.HlsDownloader do
 
   require Logger
 
+  alias SaveIt.DownloadedFile
+
   # Telegram bot API file upload limit is 50MB
   @max_file_size 49 * 1024 * 1024
 
@@ -10,7 +12,7 @@ defmodule SmallSdk.HlsDownloader do
   Download an HLS (m3u8) stream and convert it to mp4 using ffmpeg.
   Automatically selects a variant that fits within Telegram's 50MB limit.
 
-  Returns `{:ok, filename, binary_content}` or `{:error, reason}`.
+  Returns `{:ok, %SaveIt.DownloadedFile{}}` or `{:error, reason}`.
   """
   def download(m3u8_url) do
     base_url = extract_base_url(m3u8_url)
@@ -47,7 +49,7 @@ defmodule SmallSdk.HlsDownloader do
               download_best_variant(rest, original_url)
 
             {:ok, content} when byte_size(content) > 0 ->
-              {:ok, filename, content}
+              {:ok, %DownloadedFile{file_name: filename, file_content: content}}
 
             {:ok, _} ->
               {:error, "ffmpeg produced an empty file"}

--- a/lib/small_sdk/web_downloader.ex
+++ b/lib/small_sdk/web_downloader.ex
@@ -3,13 +3,15 @@ defmodule SmallSdk.WebDownloader do
 
   require Logger
 
+  alias SaveIt.DownloadedFile
+
   def download_files(urls) do
     res =
       urls
       |> Enum.map(&download_file/1)
       |> Enum.reduce_while([], fn
-        {:ok, filename, file_content, source_url}, acc ->
-          {:cont, [{filename, file_content, source_url} | acc]}
+        {:ok, %DownloadedFile{} = file}, acc ->
+          {:cont, [file | acc]}
 
         {:error, reason}, _ ->
           {:halt, {:error, reason}}
@@ -32,7 +34,13 @@ defmodule SmallSdk.WebDownloader do
 
       {:ok, %{status: status, body: body, headers: headers}} when status in 200..209 ->
         filename = parse_filename_for_url(url, headers)
-        {:ok, filename, body, url}
+
+        {:ok,
+         %DownloadedFile{
+           file_name: filename,
+           file_content: body,
+           download_url: url
+         }}
 
       {:ok, %{status: status, body: body}} ->
         Logger.error("download_file failed, status: #{status}, body: #{inspect(body)}")

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -338,8 +338,10 @@ defmodule SaveIt.BotTest do
 
     defp parse_content_length_header(line) do
       case String.split(line, ":", parts: 2) do
-        [name, value] when String.downcase(name) == "content-length" ->
-          value |> String.trim() |> String.to_integer()
+        [name, value] ->
+          if String.downcase(name) == "content-length" do
+            value |> String.trim() |> String.to_integer()
+          end
 
         _ ->
           nil

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -325,24 +325,25 @@ defmodule SaveIt.BotTest do
       {header_data, body_prefix} = split_headers(initial_data)
       [request_line | header_lines] = String.split(header_data, "\r\n", trim: true)
       [method, path, _http_version] = String.split(request_line, " ")
-
-      content_length =
-        header_lines
-        |> Enum.find_value(0, fn line ->
-          case String.split(line, ":", parts: 2) do
-            [name, value] ->
-              if String.downcase(name) == "content-length" do
-                value |> String.trim() |> String.to_integer()
-              end
-
-            _ ->
-              nil
-          end
-        end)
+      content_length = parse_content_length(header_lines)
 
       body = read_body(socket, body_prefix, content_length)
 
       {String.downcase(method) |> String.to_atom(), path, body}
+    end
+
+    defp parse_content_length(header_lines) do
+      Enum.find_value(header_lines, 0, &parse_content_length_header/1)
+    end
+
+    defp parse_content_length_header(line) do
+      case String.split(line, ":", parts: 2) do
+        [name, value] when String.downcase(name) == "content-length" ->
+          value |> String.trim() |> String.to_integer()
+
+        _ ->
+          nil
+      end
     end
 
     defp split_headers(data) do


### PR DESCRIPTION
## Summary
- introduce `DownloadContext` and `DownloadedFile` to replace flat download-flow arguments and tuple-based file payloads
- update download, cache, and upload paths to use the new structs while keeping Telegram integration behavior unchanged
- clean up existing Credo nesting issues so `mix quality` passes again

## Testing
- mix quality
