### PR TITLE
feat: announce similar photo results

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ messages:
 /similar photo
 ```
 
+When `/similar` finds matches, the bot sends `Similar photos found.` with the matching photos. Multiple matches are returned as a Telegram media group.
+
 https://github.com/user-attachments/assets/b0dedcc0-3305-42b2-8101-6b0b5d32f17a
 
 ### Known limitations

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -28,6 +28,8 @@ defmodule SaveIt.Bot do
     "Have fun! 🎉"
   ]
 
+  @similar_photos_found_message "Similar photos found."
+
   use ExGram.Bot,
     name: @bot,
     setup_commands: true
@@ -196,10 +198,7 @@ defmodule SaveIt.Bot do
             belongs_to_id: chat_id
           )
 
-        case photos do
-          [] -> nil
-          _ -> answer_photos(chat.id, photos)
-        end
+        answer_similar_photos_if_any(chat.id, photos)
     end
   end
 
@@ -241,7 +240,7 @@ defmodule SaveIt.Bot do
                 belongs_to_id: chat_id
               )
 
-            answer_photos(chat.id, photos)
+            answer_similar_photos(chat.id, photos)
 
           _ ->
             photos =
@@ -251,7 +250,7 @@ defmodule SaveIt.Bot do
                 belongs_to_id: chat_id
               )
 
-            answer_photos_if_any(chat.id, photos)
+            answer_similar_photos_if_any(chat.id, photos)
         end
     end
   end
@@ -300,6 +299,20 @@ defmodule SaveIt.Bot do
     send_message(chat_id, "No photos found.")
   end
 
+  defp answer_photos(chat_id, [photo]) do
+    case ExGram.send_photo(chat_id, photo["file_id"],
+           caption: photo["caption"],
+           show_caption_above_media: true
+         ) do
+      {:ok, _response} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to send photo: #{inspect(reason)}")
+        send_message(chat_id, "Failed to send photos.")
+    end
+  end
+
   defp answer_photos(chat_id, similar_photos) do
     media =
       Enum.map(similar_photos, fn photo ->
@@ -321,10 +334,19 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp answer_photos_if_any(_chat_id, []), do: nil
+  defp answer_similar_photos(chat_id, []) do
+    answer_photos(chat_id, [])
+  end
 
-  defp answer_photos_if_any(chat_id, photos) when is_list(photos),
-    do: answer_photos(chat_id, photos)
+  defp answer_similar_photos(chat_id, photos) when is_list(photos) do
+    send_message(chat_id, @similar_photos_found_message)
+    answer_photos(chat_id, photos)
+  end
+
+  defp answer_similar_photos_if_any(_chat_id, []), do: nil
+
+  defp answer_similar_photos_if_any(chat_id, photos) when is_list(photos),
+    do: answer_similar_photos(chat_id, photos)
 
   defp extract_urls_from_string(str) do
     regex = ~r/http[s]?:\/\/[^\s]+/

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -16,6 +16,7 @@ defmodule SaveIt.BotTest do
     Application.put_env(:ex_gram, :adapter, ExGram.Adapter.Test)
     Application.put_env(:ex_gram, :token, "test-token")
     Application.put_env(:save_it, :cobalt_api_url, base_url)
+    Application.put_env(:save_it, :telegram_bot_token, "test-token")
     Application.put_env(:save_it, :typesense_url, base_url)
     Application.put_env(:save_it, :typesense_api_key, "test-typesense-key")
 
@@ -136,6 +137,91 @@ defmodule SaveIt.BotTest do
            ]
   end
 
+  test "announces similar photos and sends multiple results as one media group", _context do
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDownloadAdapter)
+
+    ExGramTestAdapter.backdoor_request("/getFile", %{
+      file_id: "uploaded-photo-file-id",
+      file_path: "photos/uploaded.jpg"
+    })
+
+    ExGramTestAdapter.backdoor_request("/sendMessage", %{message_id: 30})
+
+    ExGramTestAdapter.backdoor_request("/sendMediaGroup", [
+      %{message_id: 31},
+      %{message_id: 32}
+    ])
+
+    message = %{
+      chat: %{id: 12_345},
+      caption: "/similar",
+      photo: [%{file_id: "uploaded-photo-file-id"}]
+    }
+
+    assert :ok = Bot.handle({:message, message}, nil)
+
+    calls = exgram_calls()
+
+    assert {:post, "/bottest-token/sendMessage",
+            %{chat_id: 12_345, text: "Similar photos found."}} in calls
+
+    media_group_calls =
+      Enum.filter(calls, fn
+        {:post, "/bottest-token/sendMediaGroup", _body} -> true
+        _ -> false
+      end)
+
+    assert [
+             {:post, "/bottest-token/sendMediaGroup", %{chat_id: 12_345, media: media}}
+           ] = media_group_calls
+
+    assert Enum.map(media, & &1.media) == ["similar-file-1", "similar-file-2"]
+    assert Enum.map(media, & &1.caption) == ["first similar", "second similar"]
+  end
+
+  test "announces similar photos and sends one result as one photo", _context do
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDownloadAdapter)
+
+    ExGramTestAdapter.backdoor_request("/getFile", %{
+      file_id: "uploaded-photo-file-id",
+      file_path: "photos/uploaded.jpg"
+    })
+
+    ExGramTestAdapter.backdoor_request("/sendMessage", %{message_id: 40})
+
+    ExGramTestAdapter.backdoor_request("/sendPhoto", %{
+      message_id: 41,
+      photo: [%{file_id: "single-similar-file"}]
+    })
+
+    message = %{
+      chat: %{id: 12_346},
+      caption: "/similar",
+      photo: [%{file_id: "uploaded-photo-file-id"}]
+    }
+
+    assert :ok = Bot.handle({:message, message}, nil)
+
+    calls = exgram_calls()
+
+    assert {:post, "/bottest-token/sendMessage",
+            %{chat_id: 12_346, text: "Similar photos found."}} in calls
+
+    assert Enum.any?(calls, fn
+             {:post, "/bottest-token/sendPhoto",
+              %{chat_id: 12_346, photo: "single-similar-file", caption: "single similar"}} ->
+               true
+
+             _ ->
+               false
+           end)
+
+    refute Enum.any?(calls, fn
+             {:post, "/bottest-token/sendMediaGroup", _body} -> true
+             _ -> false
+           end)
+  end
+
   defp cleanup_cached_file(download_url, cached_file_name) do
     hashed_url = :crypto.hash(:sha256, download_url) |> Base.url_encode64(padding: false)
     url_cache_path = Path.join(["./data/storage/urls", hashed_url])
@@ -171,6 +257,12 @@ defmodule SaveIt.BotTest do
   defp restore_env(app, key, nil), do: Application.delete_env(app, key)
   defp restore_env(app, key, value), do: Application.put_env(app, key, value)
 
+  defp exgram_calls do
+    ExGram.Adapter.Test
+    |> :sys.get_state()
+    |> Map.fetch!(:calls)
+  end
+
   defmodule TelegramMediaGroupAdapter do
     @behaviour Tesla.Adapter
 
@@ -191,6 +283,22 @@ defmodule SaveIt.BotTest do
                %{"photo" => [%{"file_id" => "group-file-4"}]}
              ]
            }
+       }}
+    end
+  end
+
+  defmodule TelegramDownloadAdapter do
+    @behaviour Tesla.Adapter
+
+    @impl Tesla.Adapter
+    def call(%Tesla.Env{method: :get} = env, _opts) do
+      send(self(), {:telegram_download_request, env})
+
+      {:ok,
+       %Tesla.Env{
+         env
+         | status: 200,
+           body: <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70>>
        }}
     end
   end
@@ -285,6 +393,18 @@ defmodule SaveIt.BotTest do
       json_response(%{"id" => "typesense-photo-id"})
     end
 
+    defp response_for("/multi_search", _port, body) do
+      %{"searches" => [%{"filter_by" => filter_by}]} = Jason.decode!(body)
+
+      json_response(%{
+        "results" => [
+          %{
+            "hits" => similar_hits(filter_by)
+          }
+        ]
+      })
+    end
+
     defp response_for("/downloaded/" <> _file_name, _port, _body) do
       jpeg = <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70>>
 
@@ -305,6 +425,34 @@ defmodule SaveIt.BotTest do
       connection: close\r
       \r
       """
+    end
+
+    defp similar_hits("belongs_to_id:12346") do
+      [
+        %{
+          "document" => %{
+            "file_id" => "single-similar-file",
+            "caption" => "single similar"
+          }
+        }
+      ]
+    end
+
+    defp similar_hits(_filter_by) do
+      [
+        %{
+          "document" => %{
+            "file_id" => "similar-file-1",
+            "caption" => "first similar"
+          }
+        },
+        %{
+          "document" => %{
+            "file_id" => "similar-file-2",
+            "caption" => "second similar"
+          }
+        }
+      ]
     end
 
     defp json_response(body) do


### PR DESCRIPTION
## Summary
- Send `Similar photos found.` before returning `/similar` matches.
- Send a single similar match with `sendPhoto` and multiple matches with `sendMediaGroup`.
- Add regression coverage for single and multiple similar-photo results.

## Test Plan
- [x] mix test
