### PR TITLE
fix(cobalt): rewrite tunnel URLs to configured API host

### DIFF
--- a/lib/small_sdk/cobalt.ex
+++ b/lib/small_sdk/cobalt.ex
@@ -12,6 +12,9 @@ defmodule SmallSdk.Cobalt do
     res = Req.post(req, json: %{url: url})
 
     case handle_response(res) do
+      {:ok, %{"status" => "tunnel", "url" => download_url}} ->
+        {:ok, normalize_tunnel_url(download_url)}
+
       {:ok, %{"url" => download_url}} ->
         {:ok, download_url}
 
@@ -45,6 +48,22 @@ defmodule SmallSdk.Cobalt do
         {"Content-Type", "application/json"}
       ]
     )
+  end
+
+  defp normalize_tunnel_url(download_url) do
+    {api_url} = get_env()
+    tunnel_uri = URI.parse(download_url)
+    api_uri = URI.parse(api_url)
+
+    case {tunnel_uri, api_uri} do
+      {%URI{path: "/tunnel"} = tunnel_uri, %URI{scheme: scheme, host: host, port: port}}
+      when is_binary(scheme) and is_binary(host) ->
+        %URI{tunnel_uri | scheme: scheme, host: host, port: port}
+        |> URI.to_string()
+
+      _ ->
+        download_url
+    end
   end
 
   @doc """

--- a/others/postmortem/2026-06-09-cobalt-tunnel-host-mismatch.md
+++ b/others/postmortem/2026-06-09-cobalt-tunnel-host-mismatch.md
@@ -1,0 +1,33 @@
+# Cobalt tunnel host mismatch
+
+## What happened
+
+Sending `https://x.com/lalisa4K/status/2057481649609453909?s=20` to the bot failed during download.
+
+Cobalt successfully resolved the post and returned a tunnel response:
+
+```json
+{
+  "status": "tunnel",
+  "url": "http://cobalt-api:9000/tunnel?...",
+  "filename": "twitter_2057481649609453909.jpg"
+}
+```
+
+When the bot runs outside the Docker network and calls Cobalt through `http://localhost:9001`, the returned `http://cobalt-api:9000/tunnel?...` URL is not resolvable from the bot process.
+
+## Root cause
+
+`SmallSdk.Cobalt.get_download_url/1` treated every response with a `url` field as a directly usable download URL. For Cobalt tunnel responses, the URL host is derived from Cobalt's own `API_URL` setting, which can differ from the host configured in `save_it` as `:cobalt_api_url`.
+
+That mismatch made the next `WebDownloader.download_file/1` request fail before reaching Cobalt.
+
+## Fix applied
+
+Tunnel responses are now handled explicitly. When Cobalt returns `status: "tunnel"`, `save_it` rewrites the tunnel URL's scheme, host, and port to match the configured `:cobalt_api_url`, while preserving the tunnel path and query.
+
+This keeps Docker-internal deployments unchanged and makes local host-based runs use the reachable published Cobalt endpoint.
+
+## What we learned
+
+Cobalt tunnel URLs should be treated as callback URLs to the same Cobalt API endpoint that `save_it` is configured to call. Direct media URLs and picker item URLs should remain untouched.

--- a/test/cobalt_test.exs
+++ b/test/cobalt_test.exs
@@ -1,7 +1,17 @@
 defmodule SmallSdk.CobaltTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias SmallSdk.Cobalt
+
+  setup do
+    previous_save_it = Application.get_all_env(:save_it)
+
+    on_exit(fn ->
+      restore_env(:save_it, previous_save_it)
+    end)
+
+    :ok
+  end
 
   test "handle_response/1 returns ok for success status" do
     response = {:ok, %{status: 200, body: %{"url" => "https://example.com/a.jpg"}}}
@@ -22,5 +32,174 @@ defmodule SmallSdk.CobaltTest do
     assert {:error, msg} = Cobalt.handle_response(response)
     assert msg =~ "Request failed"
     assert msg =~ "econnrefused"
+  end
+
+  test "get_download_url/1 rewrites tunnel urls to the configured cobalt api host" do
+    server = start_supervised!({__MODULE__.TestHttpServer, test_pid: self()})
+    base_url = "http://127.0.0.1:#{__MODULE__.TestHttpServer.port(server)}"
+
+    Application.put_env(:save_it, :cobalt_api_url, base_url)
+
+    assert {:ok, download_url} =
+             Cobalt.get_download_url("https://x.com/lalisa4K/status/2057481649609453909?s=20")
+
+    assert download_url == base_url <> "/tunnel?id=abc"
+
+    assert_receive {:test_http_request, :post, "/", body}
+
+    assert Jason.decode!(body) == %{
+             "url" => "https://x.com/lalisa4K/status/2057481649609453909"
+           }
+  end
+
+  defp restore_env(app, env) do
+    Application.get_all_env(app)
+    |> Keyword.keys()
+    |> Enum.each(&Application.delete_env(app, &1))
+
+    Enum.each(env, fn {key, value} ->
+      Application.put_env(app, key, value)
+    end)
+  end
+
+  defmodule TestHttpServer do
+    use GenServer
+
+    defstruct [:listen_socket, :port, :test_pid, :acceptor_pid]
+
+    def start_link(opts) do
+      GenServer.start_link(__MODULE__, opts)
+    end
+
+    def port(server) do
+      GenServer.call(server, :port)
+    end
+
+    def init(opts) do
+      {:ok, listen_socket} =
+        :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+      {:ok, port} = :inet.port(listen_socket)
+      test_pid = Keyword.fetch!(opts, :test_pid)
+
+      state = %__MODULE__{
+        listen_socket: listen_socket,
+        port: port,
+        test_pid: test_pid
+      }
+
+      {:ok, acceptor_pid} =
+        Task.start_link(fn ->
+          accept_loop(listen_socket, test_pid)
+        end)
+
+      {:ok, %{state | acceptor_pid: acceptor_pid}}
+    end
+
+    def handle_call(:port, _from, %{port: port} = state) do
+      {:reply, port, state}
+    end
+
+    def terminate(_reason, %{listen_socket: listen_socket, acceptor_pid: acceptor_pid}) do
+      if is_pid(acceptor_pid) do
+        Process.exit(acceptor_pid, :normal)
+      end
+
+      :gen_tcp.close(listen_socket)
+      :ok
+    end
+
+    defp accept_loop(listen_socket, test_pid) do
+      case :gen_tcp.accept(listen_socket) do
+        {:ok, socket} ->
+          handle_socket(socket, test_pid)
+          accept_loop(listen_socket, test_pid)
+
+        {:error, :closed} ->
+          :ok
+      end
+    end
+
+    defp handle_socket(socket, test_pid) do
+      {method, path, body} = read_http_request(socket)
+      send(test_pid, {:test_http_request, method, path, body})
+      :gen_tcp.send(socket, response_for(path))
+      :gen_tcp.close(socket)
+    end
+
+    defp response_for("/") do
+      json_response(%{
+        "status" => "tunnel",
+        "url" => "http://cobalt-api:9000/tunnel?id=abc",
+        "filename" => "twitter_2057481649609453909.jpg"
+      })
+    end
+
+    defp response_for(_path) do
+      """
+      HTTP/1.1 404 Not Found\r
+      content-length: 0\r
+      connection: close\r
+      \r
+      """
+    end
+
+    defp json_response(body) do
+      encoded_body = Jason.encode!(body)
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: application/json\r
+      content-length: #{byte_size(encoded_body)}\r
+      connection: close\r
+      \r
+      #{encoded_body}
+      """
+    end
+
+    defp read_http_request(socket) do
+      {:ok, initial_data} = :gen_tcp.recv(socket, 0, 5_000)
+      {header_data, body_prefix} = split_headers(initial_data)
+      [request_line | header_lines] = String.split(header_data, "\r\n", trim: true)
+      [method, path, _http_version] = String.split(request_line, " ")
+      content_length = parse_content_length(header_lines)
+
+      body = read_body(socket, body_prefix, content_length)
+
+      {String.downcase(method) |> String.to_existing_atom(), path, body}
+    end
+
+    defp split_headers(data) do
+      case :binary.split(data, "\r\n\r\n") do
+        [headers, body] -> {headers, body}
+        [headers] -> {headers, ""}
+      end
+    end
+
+    defp parse_content_length(header_lines) do
+      header_lines
+      |> Enum.find_value(0, fn header ->
+        case String.split(header, ":", parts: 2) do
+          [name, value] ->
+            if String.downcase(name) == "content-length" do
+              String.trim(value) |> String.to_integer()
+            end
+
+          _ ->
+            nil
+        end
+      end)
+    end
+
+    defp read_body(socket, body_prefix, content_length) do
+      remaining = content_length - byte_size(body_prefix)
+
+      if remaining > 0 do
+        {:ok, rest} = :gen_tcp.recv(socket, remaining, 5_000)
+        body_prefix <> rest
+      else
+        body_prefix
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Handle Cobalt `status: "tunnel"` responses explicitly.
- Rewrite tunnel URL scheme/host/port to the configured `:cobalt_api_url` so local host-based runs can download tunnel assets.
- Add a regression test and postmortem for the X/Twitter tunnel host mismatch.

## Test Plan
- [x] `mix test test/bot_test.exs test/cobalt_test.exs`
- [x] `mix format --check-formatted lib/small_sdk/cobalt.ex test/cobalt_test.exs`
- [x] `git diff --check`
