### PR TITLE
fix: prevent oversized Telegram uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent oversized files from being uploaded to Telegram Bot API.
+
 ## [2026.6.9] - 2026-06-09
 
 ### Added

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -29,6 +29,8 @@ defmodule SaveIt.Bot do
   ]
 
   @similar_photos_found_message "Similar photos found."
+  @telegram_upload_max_file_size 50 * 1024 * 1024
+  @telegram_file_too_large_message "💔 File is too large for Telegram Bot API upload."
 
   use ExGram.Bot,
     name: @bot,
@@ -634,6 +636,25 @@ defmodule SaveIt.Bot do
     source_url = Keyword.get(opts, :source_url)
     download_url = Keyword.get(opts, :download_url)
 
+    cond do
+      telegram_upload_too_large?(content) ->
+        send_message(chat_id, @telegram_file_too_large_message)
+        {:error, :telegram_file_too_large}
+
+      true ->
+        do_bot_send_file(chat_id, file_name, content,
+          caption: caption,
+          source_url: source_url,
+          download_url: download_url
+        )
+    end
+  end
+
+  defp do_bot_send_file(chat_id, file_name, content, opts) do
+    caption = Keyword.fetch!(opts, :caption)
+    source_url = Keyword.get(opts, :source_url)
+    download_url = Keyword.get(opts, :download_url)
+
     case file_extension(file_name) do
       ext when ext in [".png", ".jpg", ".jpeg"] ->
         {:ok, msg} = ExGram.send_photo(chat_id, content, caption: caption)
@@ -641,7 +662,7 @@ defmodule SaveIt.Bot do
         file_id = get_file_id(msg)
 
         image_base64 =
-          encode_file_content(file_content)
+          encode_file_content(content)
 
         safe_index_photo(%{
           image: image_base64,
@@ -660,6 +681,17 @@ defmodule SaveIt.Bot do
 
       _ ->
         ExGram.send_document(chat_id, content, caption: caption)
+    end
+  end
+
+  defp telegram_upload_too_large?({:file_content, file_content, _file_name}) do
+    byte_size(file_content) > @telegram_upload_max_file_size
+  end
+
+  defp telegram_upload_too_large?({:file, file_path}) do
+    case File.stat(file_path) do
+      {:ok, %{size: size}} -> size > @telegram_upload_max_file_size
+      {:error, _reason} -> false
     end
   end
 

--- a/others/postmortem/2026-06-09-telegram-oversized-video-upload.md
+++ b/others/postmortem/2026-06-09-telegram-oversized-video-upload.md
@@ -1,0 +1,25 @@
+# Telegram Oversized Video Upload
+
+## What happened
+
+Downloading a long X video succeeded, but sending it to Telegram failed during
+`sendVideo` multipart upload with a closed connection.
+
+## Root cause
+
+Telegram Bot API uploads are limited to 50 MB for videos and other non-photo
+files. The bot downloaded the full MP4 and attempted to upload it without
+checking the file size first, so Telegram could close the upload connection
+before returning a structured API error.
+
+## Fix applied
+
+The bot now checks downloaded file content and cached local files before
+uploading them to Telegram. Files larger than the Bot API upload limit are not
+sent to Telegram, and the user receives a clear failure message instead.
+
+## What we learned
+
+External upload limits should be enforced before starting multipart uploads,
+especially when the remote service may terminate oversized requests without a
+JSON error response.


### PR DESCRIPTION
## Summary

- Prevent files larger than the Telegram Bot API upload limit from being sent via Telegram.
- Show a clear failure message instead of attempting `sendVideo` and hitting a closed connection.
- Document the incident in a postmortem and update the changelog.

## Verification

- `mix test`
- `mix format --check-formatted lib/save_it/bot.ex test/bot_test.exs`
- `git diff --check`

## Notes

Google Drive upload behavior was intentionally left unchanged in this PR after the resumable-upload experiment was reverted.
