### PR TITLE
feat: support direct Telegram media ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,19 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Added
+
+- Save directly uploaded Telegram photos and videos to Typesense, and upload them to Google Drive when Drive is configured.
+
+### Changed
+
+- Log original-file backup failures for directly uploaded Telegram videos without sending a user-facing message.
+- Silently skip unavailable similar media results instead of sending user-facing error messages.
+
 ### Fixed
 
+- Save directly uploaded Telegram photos and downloadable videos to local storage backups.
+- Prevent directly uploaded Telegram videos from crashing when Telegram refuses, fails, or times out while downloading the original file.
 - Prevent oversized files from being uploaded to Telegram Bot API.
 
 ## [2026.6.9] - 2026-06-09

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -187,89 +187,13 @@ defmodule SaveIt.Bot do
   end
 
   # caption: nil -> find same photos
-  def handle({:message, %{chat: chat, caption: nil, photo: photos}}, _ctx) do
-    photo = List.last(photos)
-
-    file = ExGram.get_file!(photo.file_id)
-    photo_file_content = Telegram.download_file_content!(file.file_path)
-
-    chat_id = chat.id
-
-    typesense_photo =
-      safe_typesense_create_photo(%{
-        image: Base.encode64(photo_file_content),
-        caption: "",
-        file_id: file.file_id,
-        belongs_to_id: chat_id
-      })
-
-    case typesense_photo do
-      nil ->
-        :ok
-
-      _ ->
-        photos =
-          safe_typesense_search_similar_photos(
-            typesense_photo["id"],
-            distance_threshold: 0.1,
-            belongs_to_id: chat_id
-          )
-
-        answer_similar_photos_if_any(chat.id, photos)
-    end
+  # caption: contains /similar or /search -> search similar photos; otherwise, find same photos
+  def handle({:message, %{chat: chat, photo: [_ | _] = photos} = message}, _ctx) do
+    handle_uploaded_photo(chat.id, Map.get(message, :caption), photos)
   end
 
-  # caption: contains /similar or /search -> search similar photos; otherwise, find same photos
-  def handle({:message, %{chat: chat, caption: caption, photo: photos}}, _ctx) do
-    photo = List.last(photos)
-
-    file = ExGram.get_file!(photo.file_id)
-    photo_file_content = Telegram.download_file_content!(file.file_path)
-
-    chat_id = chat.id
-
-    caption =
-      if String.contains?(caption, ["/similar", "/search"]) do
-        ""
-      else
-        caption
-      end
-
-    typesense_photo =
-      safe_typesense_create_photo(%{
-        image: Base.encode64(photo_file_content),
-        caption: caption,
-        file_id: file.file_id,
-        belongs_to_id: chat_id
-      })
-
-    case typesense_photo do
-      nil ->
-        :ok
-
-      _ ->
-        case caption do
-          "" ->
-            photos =
-              safe_typesense_search_similar_photos(
-                typesense_photo["id"],
-                distance_threshold: 0.4,
-                belongs_to_id: chat_id
-              )
-
-            answer_similar_photos(chat.id, photos)
-
-          _ ->
-            photos =
-              safe_typesense_search_similar_photos(
-                typesense_photo["id"],
-                distance_threshold: 0.1,
-                belongs_to_id: chat_id
-              )
-
-            answer_similar_photos_if_any(chat.id, photos)
-        end
-    end
+  def handle({:message, %{chat: chat, video: %{file_id: _file_id} = video} = message}, _ctx) do
+    handle_uploaded_video(chat.id, Map.get(message, :caption), video)
   end
 
   def handle({:text, text, %{chat: chat, message_id: message_id}}, _context) do
@@ -317,37 +241,38 @@ defmodule SaveIt.Bot do
   end
 
   defp answer_photos(chat_id, [photo]) do
-    case ExGram.send_photo(chat_id, photo["file_id"],
-           caption: photo["caption"],
-           show_caption_above_media: true
-         ) do
-      {:ok, _response} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.error("Failed to send photo: #{inspect(reason)}")
-        send_message(chat_id, "Failed to send photos.")
-    end
+    send_similar_media(chat_id, photo)
+    :ok
   end
 
   defp answer_photos(chat_id, similar_photos) do
-    media =
-      Enum.map(similar_photos, fn photo ->
-        %ExGram.Model.InputMediaPhoto{
-          type: "photo",
-          media: photo["file_id"],
-          caption: photo["caption"],
-          show_caption_above_media: true
-        }
-      end)
+    media = Enum.map(similar_photos, &saved_media_group_input/1)
 
     case ExGram.send_media_group(chat_id, media) do
       {:ok, _response} ->
         :ok
 
       {:error, reason} ->
-        Logger.error("Failed to send media group: #{inspect(reason)}")
-        send_message(chat_id, "Failed to send photos.")
+        Logger.warning(
+          "Failed to send similar media group, falling back to individual media: #{inspect(reason)}"
+        )
+
+        Enum.each(similar_photos, &send_similar_media(chat_id, &1))
+        :ok
+    end
+  end
+
+  defp send_similar_media(chat_id, media) do
+    case send_saved_media(chat_id, media) do
+      {:ok, _response} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "Skipping unavailable similar media file_id=#{inspect(media["file_id"])}: #{inspect(reason)}"
+        )
+
+        :error
     end
   end
 
@@ -364,6 +289,163 @@ defmodule SaveIt.Bot do
 
   defp answer_similar_photos_if_any(chat_id, photos) when is_list(photos),
     do: answer_similar_photos(chat_id, photos)
+
+  defp handle_uploaded_photo(chat_id, caption, photos) do
+    photo = List.last(photos)
+    file = ExGram.get_file!(photo.file_id)
+    file_content = Telegram.download_file_content!(file.file_path)
+    file_name = telegram_file_name(file, photo.file_id, ".jpg")
+
+    FileHelper.write_file(file_name, file_content, telegram_cache_key("photo", file.file_id))
+    GoogleDrive.upload_file_content(chat_id, file_content, file_name)
+
+    %{
+      image: Base.encode64(file_content),
+      caption: searchable_caption(caption),
+      file_id: file.file_id,
+      media_type: "photo",
+      belongs_to_id: chat_id
+    }
+    |> safe_typesense_create_photo()
+    |> answer_similar_for_uploaded_media(chat_id, caption)
+  end
+
+  defp handle_uploaded_video(chat_id, caption, video) do
+    typesense_photo =
+      video
+      |> video_thumbnail()
+      |> create_video_thumbnail_index(chat_id, caption, video.file_id)
+
+    store_uploaded_video_file(chat_id, video)
+    answer_similar_for_uploaded_media(typesense_photo, chat_id, caption)
+  end
+
+  defp create_video_thumbnail_index(nil, _chat_id, _caption, _file_id), do: nil
+
+  defp create_video_thumbnail_index(thumbnail, chat_id, caption, file_id) do
+    thumbnail_file = ExGram.get_file!(thumbnail.file_id)
+    thumbnail_content = Telegram.download_file_content!(thumbnail_file.file_path)
+
+    safe_typesense_create_photo(%{
+      image: Base.encode64(thumbnail_content),
+      caption: searchable_caption(caption),
+      file_id: file_id,
+      media_type: "video",
+      belongs_to_id: chat_id
+    })
+  end
+
+  defp store_uploaded_video_file(chat_id, video) do
+    case ExGram.get_file(video.file_id) do
+      {:ok, file} ->
+        store_uploaded_video_file_content(chat_id, video, file)
+
+      {:error, reason} ->
+        handle_uploaded_video_file_error(reason)
+    end
+  end
+
+  defp store_uploaded_video_file_content(chat_id, video, file) do
+    case Telegram.download_file_content(file.file_path) do
+      {:ok, file_content} ->
+        file_name = Map.get(video, :file_name) || telegram_file_name(file, video.file_id, ".mp4")
+        FileHelper.write_file(file_name, file_content, telegram_cache_key("video", video.file_id))
+        upload_to_google_drive_if_configured(chat_id, file_content, file_name)
+        :ok
+
+      {:error, reason} ->
+        handle_uploaded_video_file_error(reason)
+    end
+  end
+
+  defp handle_uploaded_video_file_error(reason) do
+    Logger.warning("Skipping local backup for Telegram video: #{inspect(reason)}")
+    :error
+  end
+
+  defp upload_to_google_drive_if_configured(chat_id, file_content, file_name) do
+    if GoogleDrive.configured?(chat_id) do
+      GoogleDrive.upload_file_content(chat_id, file_content, file_name)
+    else
+      :ok
+    end
+  end
+
+  defp video_thumbnail(video) do
+    Map.get(video, :thumbnail) || Map.get(video, :thumb)
+  end
+
+  defp telegram_cache_key(media_type, file_id) do
+    "telegram:#{media_type}:#{file_id}"
+  end
+
+  defp answer_similar_for_uploaded_media(nil, _chat_id, _caption), do: :ok
+
+  defp answer_similar_for_uploaded_media(typesense_photo, chat_id, caption) do
+    if search_command_caption?(caption) do
+      typesense_photo["id"]
+      |> safe_typesense_search_similar_photos(distance_threshold: 0.4, belongs_to_id: chat_id)
+      |> then(&answer_similar_photos(chat_id, &1))
+    else
+      typesense_photo["id"]
+      |> safe_typesense_search_similar_photos(distance_threshold: 0.1, belongs_to_id: chat_id)
+      |> then(&answer_similar_photos_if_any(chat_id, &1))
+    end
+  end
+
+  defp searchable_caption(caption) do
+    if search_command_caption?(caption), do: "", else: caption || ""
+  end
+
+  defp search_command_caption?(caption) when is_binary(caption) do
+    String.contains?(caption, ["/similar", "/search"])
+  end
+
+  defp search_command_caption?(_caption), do: false
+
+  defp telegram_file_name(file, file_id, fallback_extension) do
+    case Map.get(file, :file_path) do
+      file_path when is_binary(file_path) and file_path != "" ->
+        Path.basename(file_path)
+
+      _ ->
+        file_id <> fallback_extension
+    end
+  end
+
+  defp send_saved_media(chat_id, %{"media_type" => "video"} = media) do
+    ExGram.send_video(chat_id, media["file_id"],
+      caption: media["caption"],
+      supports_streaming: true,
+      show_caption_above_media: true
+    )
+  end
+
+  defp send_saved_media(chat_id, media) do
+    ExGram.send_photo(chat_id, media["file_id"],
+      caption: media["caption"],
+      show_caption_above_media: true
+    )
+  end
+
+  defp saved_media_group_input(%{"media_type" => "video"} = media) do
+    %ExGram.Model.InputMediaVideo{
+      type: "video",
+      media: media["file_id"],
+      caption: media["caption"],
+      supports_streaming: true,
+      show_caption_above_media: true
+    }
+  end
+
+  defp saved_media_group_input(media) do
+    %ExGram.Model.InputMediaPhoto{
+      type: "photo",
+      media: media["file_id"],
+      caption: media["caption"],
+      show_caption_above_media: true
+    }
+  end
 
   defp extract_urls_from_string(str) do
     regex = ~r/http[s]?:\/\/[^\s]+/
@@ -636,17 +718,15 @@ defmodule SaveIt.Bot do
     source_url = Keyword.get(opts, :source_url)
     download_url = Keyword.get(opts, :download_url)
 
-    cond do
-      telegram_upload_too_large?(content) ->
-        send_message(chat_id, @telegram_file_too_large_message)
-        {:error, :telegram_file_too_large}
-
-      true ->
-        do_bot_send_file(chat_id, file_name, content,
-          caption: caption,
-          source_url: source_url,
-          download_url: download_url
-        )
+    if telegram_upload_too_large?(content) do
+      send_message(chat_id, @telegram_file_too_large_message)
+      {:error, :telegram_file_too_large}
+    else
+      do_bot_send_file(chat_id, file_name, content,
+        caption: caption,
+        source_url: source_url,
+        download_url: download_url
+      )
     end
   end
 

--- a/lib/save_it/google_drive.ex
+++ b/lib/save_it/google_drive.ex
@@ -3,7 +3,6 @@ defmodule SaveIt.GoogleDrive do
   Google Drive integration used by the bot for optional uploads.
 
   Future improvements:
-  - Skip uploads early when Drive is not configured.
   - Move the raw API client into `SmallSdk`.
   - Support browsing and selecting folders.
   """
@@ -21,6 +20,10 @@ defmodule SaveIt.GoogleDrive do
   plug(Tesla.Middleware.JSON)
 
   @upload_type "multipart"
+
+  def configured?(chat_id) do
+    match?({:ok, _folder_id, _access_token}, upload_config(chat_id))
+  end
 
   # Google Drive folder listing is limited and may not match the public guide exactly.
   def list_files(chat_id) do
@@ -41,21 +44,26 @@ defmodule SaveIt.GoogleDrive do
   end
 
   def upload_file_content(chat_id, file_content, file_name) do
-    # oauth = FileHelper.get_google_oauth(chat_id)
-    access_token = FileHelper.get_google_access_token(chat_id)
-    folder_id = FileHelper.get_google_drive_folder_id(chat_id)
+    case upload_config(chat_id) do
+      {:ok, folder_id, access_token} ->
+        upload_file(file_name, file_content, folder_id, access_token)
 
-    upload_file(file_name, file_content, folder_id, access_token)
+      :not_configured ->
+        {:ok, :skipped}
+    end
   end
 
   def upload_files(chat_id, files) do
-    access_token = FileHelper.get_google_access_token(chat_id)
-    folder_id = FileHelper.get_google_drive_folder_id(chat_id)
+    case upload_config(chat_id) do
+      {:ok, folder_id, access_token} ->
+        Enum.map(files, fn
+          %DownloadedFile{file_name: file_name, file_content: file_content} ->
+            upload_file(file_name, file_content, folder_id, access_token)
+        end)
 
-    Enum.map(files, fn
-      %DownloadedFile{file_name: file_name, file_content: file_content} ->
-        upload_file(file_name, file_content, folder_id, access_token)
-    end)
+      :not_configured ->
+        {:ok, :skipped}
+    end
   end
 
   defp upload_file(file_name, file_content, folder_id, access_token) do
@@ -82,9 +90,16 @@ defmodule SaveIt.GoogleDrive do
   def upload_file(chat_id, file_path) do
     # settings = SettingsStore.get(chat_id)
     # oauth = FileHelper.get_google_oauth(chat_id)
-    access_token = FileHelper.get_google_access_token(chat_id)
-    folder_id = FileHelper.get_google_drive_folder_id(chat_id)
+    case upload_config(chat_id) do
+      {:ok, folder_id, access_token} ->
+        upload_file_path(file_path, folder_id, access_token)
 
+      :not_configured ->
+        {:ok, :skipped}
+    end
+  end
+
+  defp upload_file_path(file_path, folder_id, access_token) do
     metadata = %{
       name: Path.basename(file_path),
       parents: [folder_id]
@@ -107,6 +122,20 @@ defmodule SaveIt.GoogleDrive do
     )
     |> handle_response()
   end
+
+  defp upload_config(chat_id) do
+    access_token = FileHelper.get_google_access_token(chat_id)
+    folder_id = FileHelper.get_google_drive_folder_id(chat_id)
+
+    if configured_value?(access_token) and configured_value?(folder_id) do
+      {:ok, folder_id, access_token}
+    else
+      :not_configured
+    end
+  end
+
+  defp configured_value?(value) when is_binary(value), do: String.trim(value) != ""
+  defp configured_value?(_value), do: false
 
   defp build_multipart_body(metadata, file_content, boundary) do
     """

--- a/lib/save_it/photo_service.ex
+++ b/lib/save_it/photo_service.ex
@@ -14,6 +14,7 @@ defmodule SaveIt.PhotoService do
     photo_create_input =
       photo_params
       |> normalize_photo_urls()
+      |> Map.put_new(:media_type, "photo")
       |> Map.put(:belongs_to_id, Integer.to_string(belongs_to_id))
       |> Map.put(:inserted_at, DateTime.utc_now() |> DateTime.to_unix())
 

--- a/others/postmortem/2026-06-11-direct-video-download-timeout.md
+++ b/others/postmortem/2026-06-11-direct-video-download-timeout.md
@@ -1,0 +1,17 @@
+# Direct Video Download Timeout
+
+## What happened
+
+A forwarded Telegram video produced a successful `getFile` response with a `videos/*.mp4` file path, but the subsequent file content download returned `{:error, :timeout}`. The bot process raised a runtime error and stopped handling the update.
+
+## Root cause
+
+The direct video backup path used `SmallSdk.Telegram.download_file_content!/1` for the optional original video download. The bang call converted transient download failures into process crashes, even though the thumbnail had already been indexed in Typesense.
+
+## Fix applied
+
+The direct video backup path now uses the non-bang `download_file_content/1` call. When the original video download fails, the bot logs a warning, skips local and Google Drive backup for the original file, and keeps the thumbnail-based Typesense record.
+
+## What we learned
+
+A successful Telegram `getFile` response only confirms that Telegram returned a file path. It does not guarantee that downloading the file content will succeed, so optional media backups must handle content download failures without affecting searchable indexing.

--- a/others/postmortem/2026-06-11-direct-video-too-large.md
+++ b/others/postmortem/2026-06-11-direct-video-too-large.md
@@ -1,0 +1,17 @@
+# Direct Video Too Large
+
+## What happened
+
+A directly forwarded Telegram video caused the bot process to raise an `ExGram.Error` when calling `getFile` for the original video file. Telegram returned `400 Bad Request: file is too big`.
+
+## Root cause
+
+The direct video handler downloaded the original video before indexing the thumbnail. For videos larger than Telegram Bot API's file download limit, `ExGram.get_file!/2` raised before the thumbnail could be saved to Typesense.
+
+## Fix applied
+
+The video handler now indexes the Telegram video thumbnail first, then attempts the original video download for local backup and uploads it to Google Drive when Drive is configured. If Telegram refuses to provide the original video file, the bot skips the original-file backup, logs a warning, and keeps the thumbnail-based Typesense record.
+
+## What we learned
+
+Direct video ingestion must treat the original video file as optional because Telegram may allow the bot to receive the update while refusing Bot API file download for the original media. Thumbnail indexing should stay independent from original file download.

--- a/priv/typesense/migrations/20260611000000_add_media_type_to_photos.exs
+++ b/priv/typesense/migrations/20260611000000_add_media_type_to_photos.exs
@@ -1,0 +1,35 @@
+defmodule SaveIt.Typesense.Migrations.AddMediaTypeToPhotos20260611000000 do
+  @moduledoc false
+
+  alias SaveIt.TypesenseMigration
+  alias SmallSdk.Typesense
+
+  @collection_name "photos"
+
+  def version, do: "20260611000000"
+  def name, do: "add_media_type_to_photos"
+
+  def up do
+    unless TypesenseMigration.has_field?(@collection_name, "media_type") do
+      Typesense.update_collection!(@collection_name, %{
+        "fields" => [
+          %{"name" => "media_type", "type" => "string", "optional" => true}
+        ]
+      })
+    end
+  end
+
+  def down do
+    if TypesenseMigration.has_field?(@collection_name, "media_type") do
+      Typesense.update_collection!(@collection_name, %{
+        "fields" => [
+          %{"name" => "media_type", "drop" => true}
+        ]
+      })
+    end
+  end
+
+  def applied? do
+    TypesenseMigration.has_field?(@collection_name, "media_type")
+  end
+end

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -1,6 +1,8 @@
 defmodule SaveIt.BotTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias ExGram.Adapter.Test, as: ExGramTestAdapter
   alias SaveIt.Bot
   alias SaveIt.FileHelper
@@ -222,6 +224,247 @@ defmodule SaveIt.BotTest do
            end)
   end
 
+  test "silently skips similar photos that Telegram cannot send after media group failure",
+       _context do
+    Application.put_env(:ex_gram, :adapter, __MODULE__.SimilarMediaFailureAdapter)
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDownloadAdapter)
+
+    message = %{
+      chat: %{id: 12_351},
+      caption: "/similar",
+      photo: [%{file_id: "uploaded-photo-file-id"}]
+    }
+
+    assert :ok = Bot.handle({:message, message}, nil)
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_351, text: "Similar photos found."}}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMediaGroup", %{chat_id: 12_351}}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendPhoto",
+                    %{chat_id: 12_351, photo: "broken-similar-file"}}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendPhoto",
+                    %{chat_id: 12_351, photo: "sendable-similar-file"}}
+
+    refute_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_351, text: "Failed to send photos."}}
+  end
+
+  test "silently skips a single similar photo that Telegram cannot send", _context do
+    Application.put_env(:ex_gram, :adapter, __MODULE__.SimilarMediaFailureAdapter)
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDownloadAdapter)
+
+    message = %{
+      chat: %{id: 12_352},
+      caption: "/similar",
+      photo: [%{file_id: "uploaded-photo-file-id"}]
+    }
+
+    assert :ok = Bot.handle({:message, message}, nil)
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_352, text: "Similar photos found."}}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendPhoto",
+                    %{chat_id: 12_352, photo: "broken-single-similar-file"}}
+
+    refute_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_352, text: "Failed to send photos."}}
+  end
+
+  test "stores a directly uploaded photo in Typesense and Google Drive", _context do
+    chat_id = 12_348
+    stored_file_path = Path.join(["./data/storage/files", "direct-photo.jpg"])
+
+    File.rm(stored_file_path)
+    configure_google_drive(chat_id)
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDirectMediaAdapter)
+    Application.put_env(:tesla, SaveIt.GoogleDrive, adapter: __MODULE__.GoogleDriveAdapter)
+
+    on_exit(fn ->
+      File.rm(stored_file_path)
+    end)
+
+    ExGramTestAdapter.backdoor_request("/getFile", %{
+      file_id: "uploaded-photo-file-id",
+      file_path: "photos/direct-photo.jpg"
+    })
+
+    message = %{
+      chat: %{id: chat_id},
+      caption: "direct image",
+      photo: [%{file_id: "uploaded-photo-file-id"}]
+    }
+
+    Bot.handle({:message, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["caption"] == "direct image"
+    assert document["file_id"] == "uploaded-photo-file-id"
+    assert document["belongs_to_id"] == Integer.to_string(chat_id)
+    assert document["media_type"] == "photo"
+    assert document["image"] == Base.encode64(test_jpeg())
+    refute Map.has_key?(document, "url")
+    refute Map.has_key?(document, "download_url")
+
+    assert_receive {:google_drive_upload_request, drive_env}
+    assert drive_env.url == "https://www.googleapis.com/upload/drive/v3/files"
+    assert {"Authorization", "Bearer test-drive-token"} in drive_env.headers
+    assert binary_contains?(drive_env.body, ~s("name":"direct-photo.jpg"))
+    assert binary_contains?(drive_env.body, "test-drive-folder")
+    assert File.read(stored_file_path) == {:ok, test_jpeg()}
+  end
+
+  test "stores a directly uploaded video using its thumbnail for Typesense and uploads the video to Google Drive",
+       _context do
+    chat_id = 12_347
+    stored_file_path = Path.join(["./data/storage/files", "direct-video.mp4"])
+
+    File.rm(stored_file_path)
+    configure_google_drive(chat_id)
+    Application.put_env(:ex_gram, :adapter, __MODULE__.BodyAwareExGramAdapter)
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDirectMediaAdapter)
+    Application.put_env(:tesla, SaveIt.GoogleDrive, adapter: __MODULE__.GoogleDriveAdapter)
+
+    on_exit(fn ->
+      File.rm(stored_file_path)
+    end)
+
+    message = %{
+      chat: %{id: chat_id},
+      caption: "/similar",
+      video: %{
+        file_id: "uploaded-video-file-id",
+        file_name: "direct-video.mp4",
+        thumbnail: %{file_id: "uploaded-video-thumbnail-id"}
+      }
+    }
+
+    Bot.handle({:message, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["caption"] == ""
+    assert document["file_id"] == "uploaded-video-file-id"
+    assert document["belongs_to_id"] == Integer.to_string(chat_id)
+    assert document["media_type"] == "video"
+    assert document["image"] == Base.encode64(test_jpeg())
+
+    assert_receive {:google_drive_upload_request, drive_env}
+    assert {"Authorization", "Bearer test-drive-token"} in drive_env.headers
+    assert binary_contains?(drive_env.body, ~s("name":"direct-video.mp4"))
+    assert binary_contains?(drive_env.body, "test-drive-folder")
+    assert binary_contains?(drive_env.body, test_mp4())
+    assert File.read(stored_file_path) == {:ok, test_mp4()}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: ^chat_id, text: "Similar photos found."}}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendVideo",
+                    %{
+                      chat_id: ^chat_id,
+                      video: "similar-video-file",
+                      caption: "similar video",
+                      supports_streaming: true
+                    }}
+  end
+
+  test "indexes a directly uploaded video thumbnail when Telegram refuses to download the large original video",
+       _context do
+    chat_id = 12_349
+
+    configure_google_drive(chat_id)
+    Application.put_env(:ex_gram, :adapter, __MODULE__.BodyAwareExGramAdapter)
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDirectMediaAdapter)
+    Application.put_env(:tesla, SaveIt.GoogleDrive, adapter: __MODULE__.GoogleDriveAdapter)
+
+    message = %{
+      chat: %{id: chat_id},
+      caption: "1-6",
+      video: %{
+        file_id: "oversized-video-file-id",
+        file_name: "AI-voice-001.mp4",
+        file_size: 33_527_186,
+        thumbnail: %{file_id: "uploaded-video-thumbnail-id"}
+      }
+    }
+
+    log =
+      capture_log(fn ->
+        Bot.handle({:message, message}, nil)
+      end)
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["caption"] == "1-6"
+    assert document["file_id"] == "oversized-video-file-id"
+    assert document["belongs_to_id"] == Integer.to_string(chat_id)
+    assert document["media_type"] == "video"
+    assert document["image"] == Base.encode64(test_jpeg())
+
+    assert log =~ "Skipping local backup for Telegram video"
+    assert log =~ "file is too big"
+    refute_receive {:exgram_request, :post, "/bottest-token/sendMessage", %{chat_id: ^chat_id}}
+    refute_receive {:google_drive_upload_request, _drive_env}
+  end
+
+  test "indexes a directly uploaded video thumbnail when original video download times out",
+       _context do
+    chat_id = 12_350
+    stored_file_path = Path.join(["./data/storage/files", "timeout-video.mp4"])
+
+    File.rm(stored_file_path)
+    configure_google_drive(chat_id)
+    Application.put_env(:ex_gram, :adapter, __MODULE__.BodyAwareExGramAdapter)
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDirectMediaAdapter)
+    Application.put_env(:tesla, SaveIt.GoogleDrive, adapter: __MODULE__.GoogleDriveAdapter)
+
+    on_exit(fn ->
+      File.rm(stored_file_path)
+    end)
+
+    message = %{
+      chat: %{id: chat_id},
+      caption: "timeout video",
+      video: %{
+        file_id: "timeout-video-file-id",
+        file_name: "timeout-video.mp4",
+        file_size: 3_343_466,
+        thumbnail: %{file_id: "uploaded-video-thumbnail-id"}
+      }
+    }
+
+    log =
+      capture_log(fn ->
+        Bot.handle({:message, message}, nil)
+      end)
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["caption"] == "timeout video"
+    assert document["file_id"] == "timeout-video-file-id"
+    assert document["belongs_to_id"] == Integer.to_string(chat_id)
+    assert document["media_type"] == "video"
+    assert document["image"] == Base.encode64(test_jpeg())
+
+    assert log =~ "Skipping local backup for Telegram video"
+    assert log =~ ":timeout"
+    refute_receive {:exgram_request, :post, "/bottest-token/sendMessage", %{chat_id: ^chat_id}}
+    refute File.exists?(stored_file_path)
+    refute_receive {:google_drive_upload_request, _drive_env}
+  end
+
   test "returns details for a replied photo", _context do
     ExGramTestAdapter.backdoor_request("/sendMessage", %{message_id: 30})
 
@@ -309,6 +552,148 @@ defmodule SaveIt.BotTest do
     ExGram.Adapter.Test
     |> :sys.get_state()
     |> Map.fetch!(:calls)
+  end
+
+  defp configure_google_drive(chat_id) do
+    File.rm_rf("./data/settings/#{chat_id}")
+    FileHelper.set_google_access_token(chat_id, "test-drive-token")
+    FileHelper.set_google_drive_folder_id(chat_id, "test-drive-folder")
+
+    on_exit(fn ->
+      File.rm_rf("./data/settings/#{chat_id}")
+    end)
+  end
+
+  def test_jpeg do
+    <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70>>
+  end
+
+  def test_mp4 do
+    <<0, 0, 0, 24, 102, 116, 121, 112, 109, 112, 52, 50>>
+  end
+
+  defp binary_contains?(binary, pattern) do
+    :binary.match(binary, pattern) != :nomatch
+  end
+
+  defmodule BodyAwareExGramAdapter do
+    @behaviour ExGram.Adapter
+
+    @impl ExGram.Adapter
+    def request(verb, path, body) do
+      send(self(), {:exgram_request, verb, path, body})
+
+      case {verb, path, body} do
+        {:get, "/bottest-token/getFile", %{file_id: "oversized-video-file-id"}} ->
+          {:error,
+           %ExGram.Error{
+             code: 400,
+             message:
+               ~s({"ok":false,"description":"Bad Request: file is too big","error_code":400})
+           }}
+
+        {:get, "/bottest-token/getFile", %{file_id: "uploaded-video-file-id"}} ->
+          {:ok, %{file_id: "uploaded-video-file-id", file_path: "videos/direct-video.mp4"}}
+
+        {:get, "/bottest-token/getFile", %{file_id: "timeout-video-file-id"}} ->
+          {:ok, %{file_id: "timeout-video-file-id", file_path: "videos/timeout-video.mp4"}}
+
+        {:get, "/bottest-token/getFile", %{file_id: "uploaded-video-thumbnail-id"}} ->
+          {:ok,
+           %{
+             file_id: "uploaded-video-thumbnail-id",
+             file_path: "video_thumbnails/direct-video.jpg"
+           }}
+
+        {:post, "/bottest-token/sendMessage", %{chat_id: chat_id}} ->
+          {:ok, %{message_id: 50, chat: %{id: chat_id}}}
+
+        {:post, "/bottest-token/sendVideo", %{chat_id: chat_id, video: file_id}} ->
+          {:ok, %{message_id: 51, chat: %{id: chat_id}, video: %{file_id: file_id}}}
+
+        _ ->
+          {:error, %ExGram.Error{code: 404}}
+      end
+    end
+  end
+
+  defmodule TelegramDirectMediaAdapter do
+    @behaviour Tesla.Adapter
+
+    @impl Tesla.Adapter
+    def call(%Tesla.Env{method: :get, url: url} = env, _opts) do
+      send(self(), {:telegram_download_request, env})
+
+      cond do
+        String.contains?(url, "timeout-video.mp4") ->
+          {:error, :timeout}
+
+        String.contains?(url, "direct-video.mp4") ->
+          {:ok, %{env | status: 200, body: SaveIt.BotTest.test_mp4()}}
+
+        true ->
+          {:ok, %{env | status: 200, body: SaveIt.BotTest.test_jpeg()}}
+      end
+    end
+  end
+
+  defmodule SimilarMediaFailureAdapter do
+    @behaviour ExGram.Adapter
+
+    @impl ExGram.Adapter
+    def request(verb, path, body) do
+      send(self(), {:exgram_request, verb, path, body})
+
+      case {verb, path, body} do
+        {:get, "/bottest-token/getFile", %{file_id: "uploaded-photo-file-id"}} ->
+          {:ok, %{file_id: "uploaded-photo-file-id", file_path: "photos/uploaded.jpg"}}
+
+        {:post, "/bottest-token/sendMessage", %{chat_id: chat_id}} ->
+          {:ok, %{message_id: 60, chat: %{id: chat_id}}}
+
+        {:post, "/bottest-token/sendMediaGroup", %{chat_id: _chat_id}} ->
+          {:error,
+           %ExGram.Error{
+             code: 400,
+             message: "Bad Request: failed to get HTTP URL content"
+           }}
+
+        {:post, "/bottest-token/sendPhoto", %{photo: "sendable-similar-file"} = body} ->
+          {:ok,
+           %{
+             message_id: 61,
+             chat: %{id: body.chat_id},
+             photo: [%{file_id: "sendable-similar-file"}]
+           }}
+
+        {:post, "/bottest-token/sendPhoto", %{photo: "broken-similar-file"}} ->
+          {:error,
+           %ExGram.Error{
+             code: 400,
+             message: "Bad Request: wrong file identifier"
+           }}
+
+        {:post, "/bottest-token/sendPhoto", %{photo: "broken-single-similar-file"}} ->
+          {:error,
+           %ExGram.Error{
+             code: 400,
+             message: "Bad Request: wrong file identifier"
+           }}
+
+        _ ->
+          {:error, %ExGram.Error{code: 404}}
+      end
+    end
+  end
+
+  defmodule GoogleDriveAdapter do
+    @behaviour Tesla.Adapter
+
+    @impl Tesla.Adapter
+    def call(%Tesla.Env{} = env, _opts) do
+      send(self(), {:google_drive_upload_request, env})
+      {:ok, %{env | status: 200, body: %{"id" => "drive-file-id"}}}
+    end
   end
 
   defmodule TelegramMediaGroupAdapter do
@@ -499,6 +884,50 @@ defmodule SaveIt.BotTest do
           "document" => %{
             "file_id" => "single-similar-file",
             "caption" => "single similar"
+          }
+        }
+      ]
+    end
+
+    defp similar_hits("belongs_to_id:12347") do
+      [
+        %{
+          "document" => %{
+            "file_id" => "similar-video-file",
+            "caption" => "similar video",
+            "media_type" => "video"
+          }
+        }
+      ]
+    end
+
+    defp similar_hits("belongs_to_id:12348"), do: []
+    defp similar_hits("belongs_to_id:12349"), do: []
+    defp similar_hits("belongs_to_id:12350"), do: []
+
+    defp similar_hits("belongs_to_id:12351") do
+      [
+        %{
+          "document" => %{
+            "file_id" => "broken-similar-file",
+            "caption" => "broken similar"
+          }
+        },
+        %{
+          "document" => %{
+            "file_id" => "sendable-similar-file",
+            "caption" => "sendable similar"
+          }
+        }
+      ]
+    end
+
+    defp similar_hits("belongs_to_id:12352") do
+      [
+        %{
+          "document" => %{
+            "file_id" => "broken-single-similar-file",
+            "caption" => "broken single similar"
           }
         }
       ]


### PR DESCRIPTION
## Summary
- Save directly uploaded Telegram photos and videos to Typesense, local storage, and Google Drive when configured.
- Index videos through their Telegram thumbnails while treating original video backup as optional and warning-log only on download failures.
- Silently skip unavailable similar media results instead of sending user-facing error messages.

## Test Plan
- [x] mix test
- [x] mix credo --strict
- [x] git diff --check
