### PR TITLE
feat: store Telegram source message links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ before the CalVer migration retain their original version labels.
 
 ### Added
 
+- Store Telegram source message links for indexed media and show them in photo details when a jump URL can be built.
 - Save directly uploaded Telegram photos and videos to Typesense, and upload them to Google Drive when Drive is configured.
 
 ### Changed
 
+- Show only available fields in photo details instead of rendering empty `N/A` rows.
 - Log original-file backup failures for directly uploaded Telegram videos without sending a user-facing message.
 - Silently skip unavailable similar media results instead of sending user-facing error messages.
 

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -189,11 +189,11 @@ defmodule SaveIt.Bot do
   # caption: nil -> find same photos
   # caption: contains /similar or /search -> search similar photos; otherwise, find same photos
   def handle({:message, %{chat: chat, photo: [_ | _] = photos} = message}, _ctx) do
-    handle_uploaded_photo(chat.id, Map.get(message, :caption), photos)
+    handle_uploaded_photo(message, chat, Map.get(message, :caption), photos)
   end
 
   def handle({:message, %{chat: chat, video: %{file_id: _file_id} = video} = message}, _ctx) do
-    handle_uploaded_video(chat.id, Map.get(message, :caption), video)
+    handle_uploaded_video(message, chat, Map.get(message, :caption), video)
   end
 
   def handle({:text, text, %{chat: chat, message_id: message_id}}, _context) do
@@ -206,7 +206,7 @@ defmodule SaveIt.Bot do
       _ ->
         has_success? =
           urls
-          |> Enum.map(&process_url(chat.id, &1))
+          |> Enum.map(&process_url(chat, &1))
           |> Enum.any?(&(&1 == :ok))
 
         if has_success? do
@@ -290,49 +290,52 @@ defmodule SaveIt.Bot do
   defp answer_similar_photos_if_any(chat_id, photos) when is_list(photos),
     do: answer_similar_photos(chat_id, photos)
 
-  defp handle_uploaded_photo(chat_id, caption, photos) do
+  defp handle_uploaded_photo(message, chat, caption, photos) do
     photo = List.last(photos)
     file = ExGram.get_file!(photo.file_id)
     file_content = Telegram.download_file_content!(file.file_path)
     file_name = telegram_file_name(file, photo.file_id, ".jpg")
 
     FileHelper.write_file(file_name, file_content, telegram_cache_key("photo", file.file_id))
-    GoogleDrive.upload_file_content(chat_id, file_content, file_name)
+    GoogleDrive.upload_file_content(chat.id, file_content, file_name)
 
     %{
       image: Base.encode64(file_content),
       caption: searchable_caption(caption),
       file_id: file.file_id,
       media_type: "photo",
-      belongs_to_id: chat_id
+      belongs_to_id: chat.id
     }
+    |> Map.merge(source_message_fields(chat, message_id(message)))
     |> safe_typesense_create_photo()
-    |> answer_similar_for_uploaded_media(chat_id, caption)
+    |> answer_similar_for_uploaded_media(chat.id, caption)
   end
 
-  defp handle_uploaded_video(chat_id, caption, video) do
+  defp handle_uploaded_video(message, chat, caption, video) do
     typesense_photo =
       video
       |> video_thumbnail()
-      |> create_video_thumbnail_index(chat_id, caption, video.file_id)
+      |> create_video_thumbnail_index(chat, message_id(message), caption, video.file_id)
 
-    store_uploaded_video_file(chat_id, video)
-    answer_similar_for_uploaded_media(typesense_photo, chat_id, caption)
+    store_uploaded_video_file(chat.id, video)
+    answer_similar_for_uploaded_media(typesense_photo, chat.id, caption)
   end
 
-  defp create_video_thumbnail_index(nil, _chat_id, _caption, _file_id), do: nil
+  defp create_video_thumbnail_index(nil, _chat, _message_id, _caption, _file_id), do: nil
 
-  defp create_video_thumbnail_index(thumbnail, chat_id, caption, file_id) do
+  defp create_video_thumbnail_index(thumbnail, chat, message_id, caption, file_id) do
     thumbnail_file = ExGram.get_file!(thumbnail.file_id)
     thumbnail_content = Telegram.download_file_content!(thumbnail_file.file_path)
 
-    safe_typesense_create_photo(%{
+    %{
       image: Base.encode64(thumbnail_content),
       caption: searchable_caption(caption),
       file_id: file_id,
       media_type: "video",
-      belongs_to_id: chat_id
-    })
+      belongs_to_id: chat.id
+    }
+    |> Map.merge(source_message_fields(chat, message_id))
+    |> safe_typesense_create_photo()
   end
 
   defp store_uploaded_video_file(chat_id, video) do
@@ -468,11 +471,13 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp process_url(chat_id, url) do
+  defp process_url(chat, url) do
+    chat_id = chat.id
     {:ok, progress_message} = send_message(chat_id, Enum.at(@progress, 0))
 
     context = %DownloadContext{
       chat_id: chat_id,
+      chat: chat,
       progress_message_id: progress_message.message_id,
       original_url: url
     }
@@ -524,7 +529,12 @@ defmodule SaveIt.Bot do
 
       downloaded_files ->
         update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
-        bot_send_filenames(context.chat_id, downloaded_files, source_url: context.original_url)
+
+        bot_send_filenames(context.chat_id, downloaded_files,
+          source_url: context.original_url,
+          source_chat: context.chat
+        )
+
         delete_message(context.chat_id, context.progress_message_id)
         :ok
     end
@@ -536,7 +546,12 @@ defmodule SaveIt.Bot do
     case WebDownloader.download_files(download_urls) do
       {:ok, files} ->
         update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
-        bot_send_files(context.chat_id, files, source_url: context.original_url)
+
+        bot_send_files(context.chat_id, files,
+          source_url: context.original_url,
+          source_chat: context.chat
+        )
+
         delete_message(context.chat_id, context.progress_message_id)
         FileHelper.write_folder(context.purge_url, files)
         GoogleDrive.upload_files(context.chat_id, files)
@@ -558,7 +573,8 @@ defmodule SaveIt.Bot do
 
         bot_send_file(context.chat_id, downloaded_file, {:file, downloaded_file},
           source_url: context.original_url,
-          download_url: context.download_url
+          download_url: context.download_url,
+          source_chat: context.chat
         )
 
         delete_message(context.chat_id, context.progress_message_id)
@@ -572,7 +588,12 @@ defmodule SaveIt.Bot do
     case WebDownloader.download_file(context.download_url) do
       {:ok, %DownloadedFile{} = file} ->
         update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
-        bot_send_downloaded_file(context.chat_id, file, source_url: context.original_url)
+
+        bot_send_downloaded_file(context.chat_id, file,
+          source_url: context.original_url,
+          source_chat: context.chat
+        )
+
         finalize_single_download(context, file)
 
       _ ->
@@ -606,6 +627,7 @@ defmodule SaveIt.Bot do
 
   defp bot_send_files(chat_id, files, opts) do
     source_url = Keyword.get(opts, :source_url)
+    source_chat = Keyword.get(opts, :source_chat)
 
     if all_images?(files) and length(files) > 1 do
       bot_send_media_group(
@@ -613,11 +635,12 @@ defmodule SaveIt.Bot do
         Enum.map(files, fn %DownloadedFile{} = file ->
           {file.file_name, {:file_content, file.file_content, file.file_name}, source_url,
            file.download_url}
-        end)
+        end),
+        source_chat: source_chat
       )
     else
       Enum.each(files, fn %DownloadedFile{} = file ->
-        bot_send_downloaded_file(chat_id, file, source_url: source_url)
+        bot_send_downloaded_file(chat_id, file, source_url: source_url, source_chat: source_chat)
       end)
     end
   end
@@ -633,20 +656,27 @@ defmodule SaveIt.Bot do
 
   defp bot_send_filenames(chat_id, filenames, opts) do
     source_url = Keyword.get(opts, :source_url)
+    source_chat = Keyword.get(opts, :source_chat)
 
     if all_images?(filenames) and length(filenames) > 1 do
       bot_send_media_group(
         chat_id,
-        Enum.map(filenames, fn filename -> {filename, {:file, filename}, source_url} end)
+        Enum.map(filenames, fn filename -> {filename, {:file, filename}, source_url} end),
+        source_chat: source_chat
       )
     else
       Enum.each(filenames, fn filename ->
-        bot_send_file(chat_id, filename, {:file, filename}, source_url: source_url)
+        bot_send_file(chat_id, filename, {:file, filename},
+          source_url: source_url,
+          source_chat: source_chat
+        )
       end)
     end
   end
 
-  defp bot_send_media_group(chat_id, files) do
+  defp bot_send_media_group(chat_id, files, opts) do
+    source_chat = Keyword.get(opts, :source_chat) || %{id: chat_id}
+
     case Telegram.send_media_group(chat_id, files) do
       {:ok, messages} ->
         Enum.zip(files, messages)
@@ -655,37 +685,43 @@ defmodule SaveIt.Bot do
             file_id = get_file_id(msg)
             image_base64 = encode_file_content(content)
 
-            PhotoService.create_photo!(%{
+            %{
               image: image_base64,
               caption: "",
               file_id: file_id,
               url: source_url,
               download_url: download_url,
               belongs_to_id: chat_id
-            })
+            }
+            |> Map.merge(source_message_fields(source_chat, message_id(msg)))
+            |> PhotoService.create_photo!()
 
           {{_file_name, content, source_url}, msg} ->
             file_id = get_file_id(msg)
             image_base64 = encode_file_content(content)
 
-            PhotoService.create_photo!(%{
+            %{
               image: image_base64,
               caption: "",
               file_id: file_id,
               url: source_url,
               belongs_to_id: chat_id
-            })
+            }
+            |> Map.merge(source_message_fields(source_chat, message_id(msg)))
+            |> PhotoService.create_photo!()
 
           {{_file_name, content}, msg} ->
             file_id = get_file_id(msg)
             image_base64 = encode_file_content(content)
 
-            PhotoService.create_photo!(%{
+            %{
               image: image_base64,
               caption: "",
               file_id: file_id,
               belongs_to_id: chat_id
-            })
+            }
+            |> Map.merge(source_message_fields(source_chat, message_id(msg)))
+            |> PhotoService.create_photo!()
         end)
 
       {:error, reason} ->
@@ -695,19 +731,23 @@ defmodule SaveIt.Bot do
           {file_name, content, source_url, download_url} ->
             bot_send_file(chat_id, file_name, content,
               source_url: source_url,
-              download_url: download_url
+              download_url: download_url,
+              source_chat: source_chat
             )
 
           {file_name, content, source_url} ->
-            bot_send_file(chat_id, file_name, content, source_url: source_url)
+            bot_send_file(chat_id, file_name, content,
+              source_url: source_url,
+              source_chat: source_chat
+            )
 
           {file_name, content} ->
-            bot_send_file(chat_id, file_name, content)
+            bot_send_file(chat_id, file_name, content, source_chat: source_chat)
         end)
     end
   end
 
-  defp bot_send_file(chat_id, file_name, file_content, opts \\ []) do
+  defp bot_send_file(chat_id, file_name, file_content, opts) do
     content =
       case file_content do
         {:file, file} -> {:file, file}
@@ -717,6 +757,7 @@ defmodule SaveIt.Bot do
     caption = Keyword.get(opts, :caption, "")
     source_url = Keyword.get(opts, :source_url)
     download_url = Keyword.get(opts, :download_url)
+    source_chat = Keyword.get(opts, :source_chat) || %{id: chat_id}
 
     if telegram_upload_too_large?(content) do
       send_message(chat_id, @telegram_file_too_large_message)
@@ -725,7 +766,8 @@ defmodule SaveIt.Bot do
       do_bot_send_file(chat_id, file_name, content,
         caption: caption,
         source_url: source_url,
-        download_url: download_url
+        download_url: download_url,
+        source_chat: source_chat
       )
     end
   end
@@ -734,6 +776,7 @@ defmodule SaveIt.Bot do
     caption = Keyword.fetch!(opts, :caption)
     source_url = Keyword.get(opts, :source_url)
     download_url = Keyword.get(opts, :download_url)
+    source_chat = Keyword.fetch!(opts, :source_chat)
 
     case file_extension(file_name) do
       ext when ext in [".png", ".jpg", ".jpeg"] ->
@@ -744,14 +787,16 @@ defmodule SaveIt.Bot do
         image_base64 =
           encode_file_content(content)
 
-        safe_index_photo(%{
+        %{
           image: image_base64,
           caption: caption,
           file_id: file_id,
           url: source_url,
           download_url: download_url,
           belongs_to_id: chat_id
-        })
+        }
+        |> Map.merge(source_message_fields(source_chat, message_id(msg)))
+        |> safe_index_photo()
 
       ".mp4" ->
         ExGram.send_video(chat_id, content, supports_streaming: true, caption: caption)
@@ -825,6 +870,51 @@ defmodule SaveIt.Bot do
         nil
     end
   end
+
+  defp message_id(message) when is_map(message) do
+    Map.get(message, :message_id) || Map.get(message, "message_id")
+  end
+
+  defp message_id(_message), do: nil
+
+  defp source_message_fields(chat, message_id) when is_integer(message_id) do
+    %{}
+    |> Map.put(:source_message_id, message_id)
+    |> put_optional(:source_message_url, telegram_message_url(chat, message_id))
+  end
+
+  defp source_message_fields(_chat, _message_id), do: %{}
+
+  defp telegram_message_url(chat, message_id) do
+    username = map_value(chat, :username)
+    chat_id = map_value(chat, :id)
+    private_channel_id = telegram_private_channel_id(chat_id)
+
+    cond do
+      is_binary(username) and username != "" ->
+        "https://t.me/#{username}/#{message_id}"
+
+      private_channel_id ->
+        "https://t.me/c/#{private_channel_id}/#{message_id}"
+
+      true ->
+        nil
+    end
+  end
+
+  defp telegram_private_channel_id(chat_id) do
+    chat_id = to_string(chat_id)
+
+    if String.starts_with?(chat_id, "-100") do
+      String.replace_prefix(chat_id, "-100", "")
+    end
+  end
+
+  defp map_value(map, key) when is_map(map), do: Map.get(map, key) || Map.get(map, to_string(key))
+  defp map_value(_map, _key), do: nil
+
+  defp put_optional(map, _key, nil), do: map
+  defp put_optional(map, key, value), do: Map.put(map, key, value)
 
   defp safe_index_photo(photo_params) do
     case safe_typesense_create_photo(photo_params) do
@@ -921,21 +1011,20 @@ defmodule SaveIt.Bot do
 
   defp detail_message(reply_to_message, photo, file_id) do
     [
-      "Sent at: #{format_unix_time(Map.get(reply_to_message, :date))}",
-      "Original URL: #{detail_value(photo, "url")}",
-      "Download URL: #{detail_value(photo, "download_url")}",
-      "File ID: #{file_id}",
-      "Typesense ID: #{detail_value(photo, "id")}"
+      detail_line("Sent at", format_unix_time(Map.get(reply_to_message, :date))),
+      detail_line("Original URL", Map.get(photo, "url")),
+      detail_line("Download URL", Map.get(photo, "download_url")),
+      detail_line("Message URL", Map.get(photo, "source_message_url")),
+      detail_line("File ID", file_id),
+      detail_line("Typesense ID", Map.get(photo, "id"))
     ]
+    |> Enum.reject(&is_nil/1)
     |> Enum.join("\n")
   end
 
-  defp detail_value(photo, key) do
-    case Map.get(photo, key) do
-      value when is_binary(value) and value != "" -> value
-      _ -> "N/A"
-    end
-  end
+  defp detail_line(_label, nil), do: nil
+  defp detail_line(_label, ""), do: nil
+  defp detail_line(label, value), do: "#{label}: #{value}"
 
   defp format_unix_time(timestamp) when is_integer(timestamp) do
     timestamp
@@ -943,7 +1032,7 @@ defmodule SaveIt.Bot do
     |> Calendar.strftime("%Y-%m-%d %H:%M:%S UTC")
   end
 
-  defp format_unix_time(_timestamp), do: "N/A"
+  defp format_unix_time(_timestamp), do: nil
 
   defp safe_typesense_get_photo(file_id, belongs_to_id) do
     PhotoService.get_photo(file_id, belongs_to_id)

--- a/lib/save_it/download_context.ex
+++ b/lib/save_it/download_context.ex
@@ -2,5 +2,13 @@ defmodule SaveIt.DownloadContext do
   @moduledoc false
 
   @enforce_keys [:chat_id, :progress_message_id, :original_url]
-  defstruct [:chat_id, :progress_message_id, :original_url, :download_url, :purge_url, :cache_url]
+  defstruct [
+    :chat_id,
+    :chat,
+    :progress_message_id,
+    :original_url,
+    :download_url,
+    :purge_url,
+    :cache_url
+  ]
 end

--- a/priv/typesense/migrations/20260611001000_add_source_message_to_photos.exs
+++ b/priv/typesense/migrations/20260611001000_add_source_message_to_photos.exs
@@ -1,0 +1,44 @@
+defmodule SaveIt.Typesense.Migrations.AddSourceMessageToPhotos20260611001000 do
+  @moduledoc false
+
+  alias SaveIt.TypesenseMigration
+  alias SmallSdk.Typesense
+
+  @collection_name "photos"
+  @fields [
+    %{"name" => "source_message_id", "type" => "int64", "optional" => true},
+    %{"name" => "source_message_url", "type" => "string", "optional" => true}
+  ]
+
+  def version, do: "20260611001000"
+  def name, do: "add_source_message_to_photos"
+
+  def up do
+    fields_to_add =
+      Enum.reject(@fields, fn %{"name" => name} ->
+        TypesenseMigration.has_field?(@collection_name, name)
+      end)
+
+    if fields_to_add != [] do
+      Typesense.update_collection!(@collection_name, %{"fields" => fields_to_add})
+    end
+  end
+
+  def down do
+    fields_to_drop =
+      @fields
+      |> Enum.map(&Map.fetch!(&1, "name"))
+      |> Enum.filter(&TypesenseMigration.has_field?(@collection_name, &1))
+      |> Enum.map(&%{"name" => &1, "drop" => true})
+
+    if fields_to_drop != [] do
+      Typesense.update_collection!(@collection_name, %{"fields" => fields_to_drop})
+    end
+  end
+
+  def applied? do
+    Enum.all?(@fields, fn %{"name" => name} ->
+      TypesenseMigration.has_field?(@collection_name, name)
+    end)
+  end
+end

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -66,7 +66,7 @@ defmodule SaveIt.BotTest do
     end)
 
     message = %{
-      chat: %{id: 12_345},
+      chat: %{id: 12_345, username: "save_it_test_chat"},
       message_id: 99
     }
 
@@ -83,6 +83,8 @@ defmodule SaveIt.BotTest do
     assert document["download_url"] == download_url
     assert document["file_id"] == "telegram-photo-file-id"
     assert document["belongs_to_id"] == "12345"
+    assert document["source_message_id"] == 20
+    assert document["source_message_url"] == "https://t.me/save_it_test_chat/20"
   end
 
   test "stores the original user-sent url for every photo in a multi-image download", _context do
@@ -98,7 +100,7 @@ defmodule SaveIt.BotTest do
     Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramMediaGroupAdapter)
 
     message = %{
-      chat: %{id: 12_345},
+      chat: %{id: 12_345, username: "save_it_test_chat"},
       message_id: 100
     }
 
@@ -136,6 +138,15 @@ defmodule SaveIt.BotTest do
              "group-file-2",
              "group-file-3",
              "group-file-4"
+           ]
+
+    assert Enum.map(documents, & &1["source_message_id"]) == [101, 102, 103, 104]
+
+    assert Enum.map(documents, & &1["source_message_url"]) == [
+             "https://t.me/save_it_test_chat/101",
+             "https://t.me/save_it_test_chat/102",
+             "https://t.me/save_it_test_chat/103",
+             "https://t.me/save_it_test_chat/104"
            ]
   end
 
@@ -293,7 +304,8 @@ defmodule SaveIt.BotTest do
     })
 
     message = %{
-      chat: %{id: chat_id},
+      chat: %{id: chat_id, username: "save_it_directs"},
+      message_id: 321,
       caption: "direct image",
       photo: [%{file_id: "uploaded-photo-file-id"}]
     }
@@ -309,6 +321,8 @@ defmodule SaveIt.BotTest do
     assert document["belongs_to_id"] == Integer.to_string(chat_id)
     assert document["media_type"] == "photo"
     assert document["image"] == Base.encode64(test_jpeg())
+    assert document["source_message_id"] == 321
+    assert document["source_message_url"] == "https://t.me/save_it_directs/321"
     refute Map.has_key?(document, "url")
     refute Map.has_key?(document, "download_url")
 
@@ -336,7 +350,8 @@ defmodule SaveIt.BotTest do
     end)
 
     message = %{
-      chat: %{id: chat_id},
+      chat: %{id: chat_id, username: "save_it_directs"},
+      message_id: 322,
       caption: "/similar",
       video: %{
         file_id: "uploaded-video-file-id",
@@ -356,6 +371,8 @@ defmodule SaveIt.BotTest do
     assert document["belongs_to_id"] == Integer.to_string(chat_id)
     assert document["media_type"] == "video"
     assert document["image"] == Base.encode64(test_jpeg())
+    assert document["source_message_id"] == 322
+    assert document["source_message_url"] == "https://t.me/save_it_directs/322"
 
     assert_receive {:google_drive_upload_request, drive_env}
     assert {"Authorization", "Bearer test-drive-token"} in drive_env.headers
@@ -496,7 +513,39 @@ defmodule SaveIt.BotTest do
     assert request_body.text =~ "Sent at: 2024-06-01 00:00:00 UTC"
     assert request_body.text =~ "Original URL: #{original_url}"
     assert request_body.text =~ "Download URL: #{download_url}"
+    assert request_body.text =~ "Message URL: https://t.me/save_it_test_chat/20"
     assert request_body.text =~ "File ID: telegram-photo-file-id"
+  end
+
+  test "omits missing values from photo details", _context do
+    ExGramTestAdapter.backdoor_request("/sendMessage", %{message_id: 30})
+
+    chat_id = 12_345
+
+    message = %{
+      chat: %{id: chat_id},
+      reply_to_message: %{
+        photo: [
+          %{file_id: "small-photo-file-id"},
+          %{file_id: "old-photo-file-id"}
+        ]
+      }
+    }
+
+    assert {:ok, %{message_id: 30}} = Bot.handle({:command, :detail, message}, nil)
+
+    assert_receive {:test_http_request, :get, search_path, ""}
+    assert search_path =~ "file_id%3A%3Dold-photo-file-id"
+
+    request_body = sent_message_body()
+
+    assert request_body.chat_id == chat_id
+    assert request_body.text == "File ID: old-photo-file-id\nTypesense ID: old-typesense-photo-id"
+    refute request_body.text =~ "N/A"
+    refute request_body.text =~ "Sent at:"
+    refute request_body.text =~ "Original URL:"
+    refute request_body.text =~ "Download URL:"
+    refute request_body.text =~ "Message URL:"
   end
 
   defp cleanup_cached_file(download_url, cached_file_name) do
@@ -710,10 +759,10 @@ defmodule SaveIt.BotTest do
            body: %{
              "ok" => true,
              "result" => [
-               %{"photo" => [%{"file_id" => "group-file-1"}]},
-               %{"photo" => [%{"file_id" => "group-file-2"}]},
-               %{"photo" => [%{"file_id" => "group-file-3"}]},
-               %{"photo" => [%{"file_id" => "group-file-4"}]}
+               %{"message_id" => 101, "photo" => [%{"file_id" => "group-file-1"}]},
+               %{"message_id" => 102, "photo" => [%{"file_id" => "group-file-2"}]},
+               %{"message_id" => 103, "photo" => [%{"file_id" => "group-file-3"}]},
+               %{"message_id" => 104, "photo" => [%{"file_id" => "group-file-4"}]}
              ]
            }
        }}
@@ -822,19 +871,33 @@ defmodule SaveIt.BotTest do
       end
     end
 
-    defp response_for("/collections/photos/documents/search?" <> _query, port, _body) do
+    defp response_for("/collections/photos/documents/search?" <> query, port, _body) do
+      document =
+        if query =~ "file_id%3A%3Dold-photo-file-id" do
+          %{
+            "id" => "old-typesense-photo-id",
+            "caption" => "",
+            "file_id" => "old-photo-file-id",
+            "belongs_to_id" => "12345",
+            "inserted_at" => 1_717_200_000
+          }
+        else
+          %{
+            "id" => "typesense-photo-id",
+            "caption" => "",
+            "file_id" => "telegram-photo-file-id",
+            "url" => "https://x.com/example/status/1?utm_source=telegram",
+            "download_url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg",
+            "source_message_url" => "https://t.me/save_it_test_chat/20",
+            "belongs_to_id" => "12345",
+            "inserted_at" => 1_717_200_000
+          }
+        end
+
       json_response(%{
         "hits" => [
           %{
-            "document" => %{
-              "id" => "typesense-photo-id",
-              "caption" => "",
-              "file_id" => "telegram-photo-file-id",
-              "url" => "https://x.com/example/status/1?utm_source=telegram",
-              "download_url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg",
-              "belongs_to_id" => "12345",
-              "inserted_at" => 1_717_200_000
-            }
+            "document" => document
           }
         ]
       })


### PR DESCRIPTION
## Summary
- Store Telegram source message metadata for indexed photos and video thumbnails.
- Build jump URLs for public chats and private supergroups/channels when possible.
- Show concise `/detail` output with only available fields.

## Migration
- Run `mix ts.migrate` to add optional `source_message_id` and `source_message_url` fields to the Typesense `photos` collection.

## Test Plan
- [x] `mix format --check-formatted`
- [x] `mix test test/bot_test.exs`
- [x] `mix test`
