### PR TITLE
chore: use local mix deps path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ before the CalVer migration retain their original version labels.
 
 - Log original-file backup failures for directly uploaded Telegram videos without sending a user-facing message.
 - Silently skip unavailable similar media results instead of sending user-facing error messages.
+- Use a worktree-local Mix dependencies directory under `mise` to avoid dependency cache conflicts across branches.
 
 ### Fixed
 

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ elixir = "1.19.5"
 
 [env]
 _.file = '.env'
+MIX_DEPS_PATH = "deps"
 
 [tasks.update-zeabur-template]
 description = "Update Zeabur template"


### PR DESCRIPTION
## Summary

- Configure `mise` to use the repository-local `deps` directory for Mix dependencies.
- Document the workflow change in `CHANGELOG.md`.

## Why

The global `mise` config used a shared dependency cache based on the checkout basename. Multiple `save_it` worktrees could therefore share one Mix deps source directory, causing dependency version conflicts and repeated compilation.

## Verification

- `mise exec -- mix deps`
- `mise exec -- mix compile`
