### PR TITLE
feat: save link thumbnails as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ before the CalVer migration retain their original version labels.
 ### Fixed
 
 - Save directly uploaded Telegram photos and downloadable videos to local storage backups.
+- Save Telegram-provided thumbnails without a user-facing failure message when a user-sent link cannot be downloaded.
 - Prevent directly uploaded Telegram videos from crashing when Telegram refuses, fails, or times out while downloading the original file.
 - Prevent oversized files from being uploaded to Telegram Bot API.
 

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -196,7 +196,7 @@ defmodule SaveIt.Bot do
     handle_uploaded_video(chat.id, Map.get(message, :caption), video)
   end
 
-  def handle({:text, text, %{chat: chat, message_id: message_id}}, _context) do
+  def handle({:text, text, %{chat: chat, message_id: message_id} = message}, _context) do
     urls = extract_urls_from_string(text)
 
     case urls do
@@ -206,7 +206,7 @@ defmodule SaveIt.Bot do
       _ ->
         has_success? =
           urls
-          |> Enum.map(&process_url(chat.id, &1))
+          |> Enum.map(&process_url(chat.id, &1, message))
           |> Enum.any?(&(&1 == :ok))
 
         if has_success? do
@@ -468,13 +468,14 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp process_url(chat_id, url) do
+  defp process_url(chat_id, url, message) do
     {:ok, progress_message} = send_message(chat_id, Enum.at(@progress, 0))
 
     context = %DownloadContext{
       chat_id: chat_id,
       progress_message_id: progress_message.message_id,
-      original_url: url
+      original_url: url,
+      message: message
     }
 
     case get_download_url(url) do
@@ -491,9 +492,8 @@ defmodule SaveIt.Bot do
             cache_url: download_url
         })
 
-      {:error, _} ->
-        update_message(chat_id, context.progress_message_id, "💔 Failed to get download URL.")
-        :error
+      {:error, reason} ->
+        handle_download_failure(context, "💔 Failed to get download URL.", reason)
     end
   end
 
@@ -506,14 +506,8 @@ defmodule SaveIt.Bot do
         bot_send_downloaded_file(context.chat_id, file)
         finalize_single_download(context, file)
 
-      {:error, _reason} ->
-        update_message(
-          context.chat_id,
-          context.progress_message_id,
-          "💔 Failed downloading HLS video."
-        )
-
-        :error
+      {:error, reason} ->
+        handle_download_failure(context, "💔 Failed downloading HLS video.", reason)
     end
   end
 
@@ -542,9 +536,8 @@ defmodule SaveIt.Bot do
         GoogleDrive.upload_files(context.chat_id, files)
         :ok
 
-      _ ->
-        update_message(context.chat_id, context.progress_message_id, "💔 Failed downloading file.")
-        :error
+      {:error, reason} ->
+        handle_download_failure(context, "💔 Failed downloading file.", reason)
     end
   end
 
@@ -575,10 +568,95 @@ defmodule SaveIt.Bot do
         bot_send_downloaded_file(context.chat_id, file, source_url: context.original_url)
         finalize_single_download(context, file)
 
-      _ ->
-        update_message(context.chat_id, context.progress_message_id, "💔 Failed downloading file.")
+      {:error, reason} ->
+        handle_download_failure(context, "💔 Failed downloading file.", reason)
+    end
+  end
+
+  defp handle_download_failure(%DownloadContext{} = context, failure_message, failure_reason) do
+    case download_message_thumbnail(context.message) do
+      {:ok, %DownloadedFile{} = file} ->
+        Logger.warning(
+          "Saved Telegram thumbnail fallback after link download failed: #{inspect(failure_reason)}"
+        )
+
+        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+
+        bot_send_downloaded_file(context.chat_id, file, source_url: context.original_url)
+        finalize_thumbnail_download(context, file)
+
+      {:error, fallback_reason} ->
+        Logger.warning(
+          "No Telegram thumbnail fallback available after link download failed: " <>
+            inspect(%{failure_reason: failure_reason, fallback_reason: fallback_reason})
+        )
+
+        update_message(context.chat_id, context.progress_message_id, failure_message)
         :error
     end
+  end
+
+  defp download_message_thumbnail(message) do
+    with thumbnail when not is_nil(thumbnail) <- message_thumbnail(message),
+         file_id when is_binary(file_id) <- map_get(thumbnail, :file_id),
+         {:ok, file} <- ExGram.get_file(file_id),
+         {:ok, file_content} <- Telegram.download_file_content(file.file_path) do
+      {:ok,
+       %DownloadedFile{
+         file_name: telegram_file_name(file, file_id, ".jpg"),
+         file_content: file_content
+       }}
+    else
+      nil -> {:error, :no_thumbnail}
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :missing_thumbnail_file_id}
+    end
+  end
+
+  defp message_thumbnail(nil), do: nil
+
+  defp message_thumbnail(message) do
+    [
+      largest_photo(map_get(message, :photo)),
+      map_get(message, :thumbnail),
+      map_get(message, :thumb),
+      media_thumbnail(map_get(message, :animation)),
+      media_thumbnail(map_get(message, :audio)),
+      media_thumbnail(map_get(message, :document)),
+      media_thumbnail(map_get(message, :video)),
+      media_thumbnail(map_get(message, :video_note)),
+      media_thumbnail(map_get(message, :sticker)),
+      message_thumbnail(map_get(message, :external_reply))
+    ]
+    |> Enum.find(&thumbnail_file?/1)
+  end
+
+  defp media_thumbnail(nil), do: nil
+
+  defp media_thumbnail(media) do
+    map_get(media, :thumbnail) || map_get(media, :thumb)
+  end
+
+  defp largest_photo([_ | _] = photos), do: List.last(photos)
+  defp largest_photo(_photos), do: nil
+
+  defp thumbnail_file?(thumbnail) do
+    thumbnail
+    |> map_get(:file_id)
+    |> is_binary()
+  end
+
+  defp map_get(nil, _key), do: nil
+
+  defp map_get(map, key) when is_map(map) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp finalize_thumbnail_download(%DownloadContext{} = context, %DownloadedFile{} = file) do
+    delete_message(context.chat_id, context.progress_message_id)
+    FileHelper.write_file(file.file_name, file.file_content, context.original_url)
+    GoogleDrive.upload_file_content(context.chat_id, file.file_content, file.file_name)
+    :ok
   end
 
   defp finalize_single_download(%DownloadContext{} = context, %DownloadedFile{} = file) do

--- a/lib/save_it/download_context.ex
+++ b/lib/save_it/download_context.ex
@@ -2,5 +2,13 @@ defmodule SaveIt.DownloadContext do
   @moduledoc false
 
   @enforce_keys [:chat_id, :progress_message_id, :original_url]
-  defstruct [:chat_id, :progress_message_id, :original_url, :download_url, :purge_url, :cache_url]
+  defstruct [
+    :chat_id,
+    :progress_message_id,
+    :original_url,
+    :download_url,
+    :purge_url,
+    :cache_url,
+    :message
+  ]
 end

--- a/others/postmortem/2026-06-11-link-thumbnail-fallback.md
+++ b/others/postmortem/2026-06-11-link-thumbnail-fallback.md
@@ -1,0 +1,17 @@
+# Link Thumbnail Fallback
+
+## What happened
+
+A user-sent link could fail during URL resolution or media download even when Telegram had already attached a usable thumbnail to the message. The bot reported the download failure and discarded the available thumbnail.
+
+## Root cause
+
+The URL download flow only passed `chat_id` and the extracted URL into `process_url/2`. Failure handlers no longer had access to the original Telegram message, so they could not inspect message photos or media thumbnails as fallback input.
+
+## Fix applied
+
+The URL download context now keeps the original Telegram message. When URL resolution, HLS download, multi-file download, or single-file download fails, the bot tries to download the largest Telegram-provided photo or media thumbnail, sends it back as a saved photo, indexes it in Typesense with the original URL, writes it to local storage, and uploads it to Google Drive through the existing link-save path. If the thumbnail fallback succeeds, the bot treats the operation as successful and logs the original download failure instead of sending a user-facing failure message.
+
+## What we learned
+
+Telegram message metadata can still contain a useful image even when the external site or downloader fails. Download fallback behavior should keep the original message available until all recovery paths have been tried.

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -85,6 +85,56 @@ defmodule SaveIt.BotTest do
     assert document["belongs_to_id"] == "12345"
   end
 
+  test "stores the Telegram thumbnail when a user-sent url cannot be resolved", _context do
+    original_url = "https://example.com/unavailable"
+
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDownloadAdapter)
+
+    ExGramTestAdapter.backdoor_request("/getFile", %{
+      file_id: "link-thumbnail-file-id",
+      file_path: "photos/link-thumbnail.jpg"
+    })
+
+    message = %{
+      chat: %{id: 12_345},
+      message_id: 101,
+      photo: [
+        %{file_id: "small-link-thumbnail-file-id"},
+        %{file_id: "link-thumbnail-file-id"}
+      ]
+    }
+
+    log =
+      capture_log(fn ->
+        assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+      end)
+
+    assert log =~ "Saved Telegram thumbnail fallback after link download failed"
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => original_url}
+
+    assert_receive {:telegram_download_request, telegram_env}
+    assert String.ends_with?(telegram_env.url, "/file/bottest-token/photos/link-thumbnail.jpg")
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    refute Map.has_key?(document, "download_url")
+    assert document["file_id"] == "telegram-photo-file-id"
+    assert document["belongs_to_id"] == "12345"
+
+    refute Enum.any?(exgram_calls(), fn
+             {:post, _path, %{text: text}} when is_binary(text) ->
+               String.contains?(text, "Failed")
+
+             _ ->
+               false
+           end)
+  end
+
   test "stores the original user-sent url for every photo in a multi-image download", _context do
     original_url = "https://x.com/JennerItGirls/status/2057529104535023815?s=20"
     purge_url = "https://x.com/JennerItGirls/status/2057529104535023815"
@@ -817,6 +867,9 @@ defmodule SaveIt.BotTest do
             ]
           })
 
+        %{"url" => "https://example.com/unavailable"} ->
+          error_response(%{"error" => "unsupported url"})
+
         unexpected ->
           raise "Unexpected cobalt request body: #{inspect(unexpected)}"
       end
@@ -955,6 +1008,19 @@ defmodule SaveIt.BotTest do
 
       """
       HTTP/1.1 200 OK\r
+      content-type: application/json\r
+      content-length: #{byte_size(encoded_body)}\r
+      connection: close\r
+      \r
+      #{encoded_body}
+      """
+    end
+
+    defp error_response(body) do
+      encoded_body = Jason.encode!(body)
+
+      """
+      HTTP/1.1 502 Bad Gateway\r
       content-type: application/json\r
       content-length: #{byte_size(encoded_body)}\r
       connection: close\r


### PR DESCRIPTION
## Summary

- Save Telegram-provided thumbnails when a user-sent link cannot be resolved or downloaded.
- Treat successful thumbnail fallback as a successful save, without sending a user-facing failure message.
- Log the original download failure and fallback result for operators.
- Preserve Telegram source message metadata after merging the latest `main` changes.
- Document the behavior in the changelog and postmortem.

## Conflict resolution

- Merged `origin/main` into `feat/link-thumbnail-fallback` without rebasing.
- Resolved conflicts in `lib/save_it/bot.ex` and `lib/save_it/download_context.ex` by keeping both `chat` for source message tracking and the original `message` for thumbnail fallback.
- Added coverage that thumbnail fallback records the bot-sent source message id/url while avoiding user-facing failure text.

## Verification

- `mix test test/bot_test.exs`
- `mix format --check-formatted`
- `mix test`
- `mix compile --warnings-as-errors`
