### PR TITLE
fix: exclude uploaded media from similar results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ before the CalVer migration retain their original version labels.
 ### Fixed
 
 - Save directly uploaded Telegram photos and downloadable videos to local storage backups.
+- Prevent `/similar` results from echoing the just uploaded Telegram media back into the chat.
 - Prevent directly uploaded Telegram videos from crashing when Telegram refuses, fails, or times out while downloading the original file.
 - Prevent oversized files from being uploaded to Telegram Bot API.
 

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -382,16 +382,40 @@ defmodule SaveIt.Bot do
   defp answer_similar_for_uploaded_media(nil, _chat_id, _caption), do: :ok
 
   defp answer_similar_for_uploaded_media(typesense_photo, chat_id, caption) do
+    similar_photos =
+      typesense_photo["id"]
+      |> safe_typesense_search_similar_photos(
+        distance_threshold: similar_search_distance_threshold(caption),
+        belongs_to_id: chat_id
+      )
+      |> exclude_uploaded_media(typesense_photo)
+
     if search_command_caption?(caption) do
-      typesense_photo["id"]
-      |> safe_typesense_search_similar_photos(distance_threshold: 0.4, belongs_to_id: chat_id)
-      |> then(&answer_similar_photos(chat_id, &1))
+      answer_similar_photos(chat_id, similar_photos)
     else
-      typesense_photo["id"]
-      |> safe_typesense_search_similar_photos(distance_threshold: 0.1, belongs_to_id: chat_id)
-      |> then(&answer_similar_photos_if_any(chat_id, &1))
+      answer_similar_photos_if_any(chat_id, similar_photos)
     end
   end
+
+  defp similar_search_distance_threshold(caption) do
+    if search_command_caption?(caption), do: 0.4, else: 0.1
+  end
+
+  defp exclude_uploaded_media(photos, uploaded_media) when is_list(photos) do
+    uploaded_file_id = Map.get(uploaded_media, "file_id")
+    uploaded_id = Map.get(uploaded_media, "id")
+
+    Enum.reject(photos, fn photo ->
+      same_present_value?(Map.get(photo, "file_id"), uploaded_file_id) or
+        same_present_value?(Map.get(photo, "id"), uploaded_id)
+    end)
+  end
+
+  defp same_present_value?(left, right) when is_binary(left) and is_binary(right) do
+    left != "" and left == right
+  end
+
+  defp same_present_value?(_left, _right), do: false
 
   defp searchable_caption(caption) do
     if search_command_caption?(caption), do: "", else: caption || ""
@@ -834,7 +858,9 @@ defmodule SaveIt.Bot do
   end
 
   defp safe_typesense_create_photo(photo_params) do
-    PhotoService.create_photo!(photo_params)
+    photo_params
+    |> PhotoService.create_photo!()
+    |> include_created_photo_metadata(photo_params)
   rescue
     error ->
       Logger.error("Typesense create_photo failed: #{Exception.message(error)}")
@@ -844,6 +870,17 @@ defmodule SaveIt.Bot do
       Logger.error("Typesense create_photo failed: #{inspect({kind, reason})}")
       nil
   end
+
+  defp include_created_photo_metadata(photo, photo_params) when is_map(photo) do
+    Enum.reduce([:file_id, :media_type], photo, fn key, acc ->
+      case Map.fetch(photo_params, key) do
+        {:ok, value} -> Map.put_new(acc, Atom.to_string(key), value)
+        :error -> acc
+      end
+    end)
+  end
+
+  defp include_created_photo_metadata(photo, _photo_params), do: photo
 
   defp safe_typesense_search_photos(q, opts) do
     PhotoService.search_photos!(q, opts)

--- a/others/postmortem/2026-06-11-similar-uploaded-media-echo.md
+++ b/others/postmortem/2026-06-11-similar-uploaded-media-echo.md
@@ -1,0 +1,17 @@
+# Similar Uploaded Media Echo
+
+## What happened
+
+When a user uploaded media with `/similar`, the bot could send the uploaded media back to the same Telegram chat as one of the similar results. This made the chat appear to contain duplicate photos.
+
+## Root cause
+
+The bot indexes the uploaded media in Typesense before running the similarity search. Typesense can return that newly created document as the nearest match, but the bot did not filter the query media out of the result list before sending media back to Telegram.
+
+## Fix applied
+
+The bot now keeps the created document response associated with the uploaded media metadata and excludes search results with the same Telegram `file_id` or Typesense document `id` before rendering similar media results.
+
+## What we learned
+
+Similarity searches that index the query item as part of the request flow must explicitly remove the query item from returned candidates before presenting results to users.

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -224,6 +224,55 @@ defmodule SaveIt.BotTest do
            end)
   end
 
+  test "does not return the just uploaded photo as a similar result", _context do
+    Application.put_env(:tesla, SmallSdk.Telegram, adapter: __MODULE__.TelegramDownloadAdapter)
+
+    ExGramTestAdapter.backdoor_request("/getFile", %{
+      file_id: "uploaded-photo-file-id",
+      file_path: "photos/uploaded.jpg"
+    })
+
+    ExGramTestAdapter.backdoor_request("/sendMessage", %{message_id: 42})
+
+    ExGramTestAdapter.backdoor_request("/sendPhoto", %{
+      message_id: 43,
+      photo: [%{file_id: "other-similar-file"}]
+    })
+
+    ExGramTestAdapter.backdoor_request("/sendMediaGroup", [
+      %{message_id: 44},
+      %{message_id: 45}
+    ])
+
+    message = %{
+      chat: %{id: 12_353},
+      caption: "/similar",
+      photo: [%{file_id: "uploaded-photo-file-id"}]
+    }
+
+    assert :ok = Bot.handle({:message, message}, nil)
+
+    calls = exgram_calls()
+
+    assert {:post, "/bottest-token/sendMessage",
+            %{chat_id: 12_353, text: "Similar photos found."}} in calls
+
+    assert Enum.any?(calls, fn
+             {:post, "/bottest-token/sendPhoto",
+              %{chat_id: 12_353, photo: "other-similar-file", caption: "other similar"}} ->
+               true
+
+             _ ->
+               false
+           end)
+
+    refute Enum.any?(calls, fn
+             {:post, "/bottest-token/sendPhoto", %{photo: "uploaded-photo-file-id"}} -> true
+             {:post, "/bottest-token/sendMediaGroup", _body} -> true
+             _ -> false
+           end)
+  end
+
   test "silently skips similar photos that Telegram cannot send after media group failure",
        _context do
     Application.put_env(:ex_gram, :adapter, __MODULE__.SimilarMediaFailureAdapter)
@@ -928,6 +977,23 @@ defmodule SaveIt.BotTest do
           "document" => %{
             "file_id" => "broken-single-similar-file",
             "caption" => "broken single similar"
+          }
+        }
+      ]
+    end
+
+    defp similar_hits("belongs_to_id:12353") do
+      [
+        %{
+          "document" => %{
+            "file_id" => "uploaded-photo-file-id",
+            "caption" => ""
+          }
+        },
+        %{
+          "document" => %{
+            "file_id" => "other-similar-file",
+            "caption" => "other similar"
           }
         }
       ]


### PR DESCRIPTION
## Summary

- Exclude the just uploaded Telegram media from `/similar` results by matching `file_id` or Typesense document `id`.
- Preserve created-photo metadata needed by the similarity result filter.
- Add a regression test plus changelog and postmortem notes for the duplicate Telegram media echo.
- Merge the latest `origin/main` into this branch to resolve the PR update/conflict state.

## Test Plan

- [x] `mix format --check-formatted lib/save_it/bot.ex test/bot_test.exs CHANGELOG.md others/postmortem/2026-06-11-similar-uploaded-media-echo.md`
- [x] `mix test test/bot_test.exs`
