### PR TITLE
feat: simplify photo details

### DIFF
--- a/.agents/skills/save-it-changelog/SKILL.md
+++ b/.agents/skills/save-it-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: save-it-changelog
-description: Maintain the save_it repository CHANGELOG.md using Keep a Changelog 1.1.0 with CalVer version headings. Use at the end of repository work, before final response or commit/PR handoff, whenever files changed or a notable project decision, user-facing behavior, operational workflow, documentation, release process, or agent workflow changed.
+description: Maintain the save_it repository CHANGELOG.md using Keep a Changelog 1.1.0 with CalVer version headings. Use at the end of repository work, before final response or commit/PR handoff, when user-facing product behavior, features, fixes, removals, security changes, or breaking changes changed.
 ---
 
 # Save It Changelog
@@ -12,10 +12,10 @@ Keep `CHANGELOG.md` as the in-repository, human-written summary of notable chang
 ## Workflow
 
 1. Open `CHANGELOG.md`. If it is missing, create it from the template below.
-2. Review the actual repository diff and summarize only notable changes. Do not dump commit logs.
+2. Review the actual repository diff and summarize only notable user-facing product changes. Do not dump commit logs.
 3. Add entries under `## [Unreleased]`, grouped by standard change types.
 4. Keep entries concise, user-facing, and understandable without reading the diff.
-5. If no notable changelog entry is warranted, leave the file unchanged and mention that in the final response.
+5. If the diff is only docs, tests, chores, internal refactors, formatting, CI, release plumbing, agent skills, or other maintainer-only workflow changes, leave the file unchanged and mention that no product changelog entry is warranted.
 
 ## Format Rules
 
@@ -31,13 +31,14 @@ Keep `CHANGELOG.md` as the in-repository, human-written summary of notable chang
 
 ## Entry Guidance
 
-- Add `Added` for new features, docs, skills, automation, or capabilities.
-- Add `Changed` for changed behavior, workflow, defaults, dependencies, or documented project policy.
+- Add `Added` for new user-facing features or product capabilities.
+- Add `Changed` for user-visible behavior, defaults, or compatibility changes.
 - Add `Fixed` for bug fixes.
-- Add `Removed` for removed behavior, files, or workflows.
+- Add `Removed` for removed user-facing behavior or product capabilities.
 - Add `Security` for vulnerability-related changes.
 - Prefer one clear bullet per meaningful change.
-- Mention implementation details only when they matter to users, operators, or future maintainers.
+- Do not record docs-only, tests-only, chore-only, formatting-only, CI-only, internal refactor-only, release-process-only, or agent-workflow-only changes.
+- Mention implementation details only when they explain a user-visible outcome or required operator action.
 
 ## Initial Template
 

--- a/.agents/skills/save-it-release/SKILL.md
+++ b/.agents/skills/save-it-release/SKILL.md
@@ -12,13 +12,16 @@ This repository uses:
 - Versioning: CalVer `YYYY.M.D` for stable releases, where the last segment is the calendar day of month (for example `2026.5.25`), with git tags using the same value without a `v` prefix, and hotfix such as `YYYY.M.D-hotfix.N`
 - git tags that match the version string directly, for example `2026.5.25`
 - GitHub Release publication to trigger `.github/workflows/release.yml`
-- The GitHub release page as the changelog surface for this project
+- `CHANGELOG.md` as the in-repository curated changelog, maintained with Keep a Changelog and CalVer headings
+- GitHub release pages as the published release-note surface
 - `.github/workflows/release-manual.yml` for manual releases
 
 ## Release Rules
 
 - The bump version commit message must be exactly `version`.
 - The release tag must be created on the bump version commit.
+- Maintain `CHANGELOG.md` only for product-focused user-facing features, behavior changes, fixes, removals, security changes, or breaking changes.
+- Before publishing a release or prerelease, roll current `Unreleased` entries into the target version heading and leave a fresh `## [Unreleased]` section above it.
 - GitHub Releases may use generated notes.
 - Any release with breaking changes must include upgrade guides covering deployment and release steps for the new version.
 
@@ -27,9 +30,10 @@ This repository uses:
 1. Read the current release state.
 2. Decide whether this is release preparation, stable release publication, or manual prerelease publication.
 3. Align `mix.exs` and the target release tag.
-4. Verify release metadata and git state.
-5. Execute the matching release path.
-6. Report the exact tag, commit, release URL, and workflow status.
+4. Align `CHANGELOG.md` with the target release tag.
+5. Verify release metadata and git state.
+6. Execute the matching release path.
+7. Report the exact tag, commit, release URL, and workflow status.
 
 ## Preflight
 
@@ -63,22 +67,24 @@ version: "YYYY.M.D"
 ```
 
 2. If the release page needs curated notes, prepare a short English draft for the GitHub release body.
-3. Show the diff for `mix.exs`.
-4. Do not tag or publish unless the user explicitly asks to release.
+3. Roll `CHANGELOG.md` `Unreleased` entries into the target release heading when preparing an actual release or prerelease.
+4. Show the diff for `mix.exs` and `CHANGELOG.md`.
+5. Do not tag or publish unless the user explicitly asks to release.
 
 ## Stable Release Publication
 
 When the user asks to publish a stable release:
 
 1. Confirm the released version exists in `mix.exs`.
-2. Commit release metadata changes using the repository convention:
+2. Confirm `CHANGELOG.md` has a heading for the released version and a fresh `## [Unreleased]` heading above it.
+3. Commit release metadata changes using the repository convention:
 
 ```bash
-git add mix.exs
+git add mix.exs CHANGELOG.md
 git commit -m "version"
 ```
 
-3. Create and push the stable tag:
+4. Create and push the stable tag:
 
 ```bash
 git tag -a YYYY.M.D -m "YYYY.M.D"
@@ -86,7 +92,7 @@ git push origin main
 git push origin refs/tags/YYYY.M.D
 ```
 
-4. Publish the GitHub release page entry. Prefer generated notes unless the user already prepared custom notes:
+5. Publish the GitHub release page entry. Prefer generated notes unless the user already prepared custom notes:
 
 ```bash
 gh release create YYYY.M.D \
@@ -95,7 +101,7 @@ gh release create YYYY.M.D \
   --generate-notes
 ```
 
-5. Check whether the `Release` workflow was triggered:
+6. Check whether the `Release` workflow was triggered:
 
 ```bash
 gh run list --limit 5
@@ -108,13 +114,14 @@ If the user wants more confidence before release, run the acceptance flow from `
 When the user asks for a prerelease:
 
 1. Keep the version in the repository's CalVer prerelease form, for example `2026.5.25-rc.1`.
-2. Prefer the existing GitHub Actions workflow instead of manually crafting a prerelease:
+2. Confirm `CHANGELOG.md` has a heading for the prerelease version and a fresh `## [Unreleased]` heading above it.
+3. Prefer the existing GitHub Actions workflow instead of manually crafting a prerelease:
 
 ```bash
 gh workflow run "Release (manual)" -f tag=YYYY.M.D-rc.N
 ```
 
-3. This workflow publishes a GitHub prerelease and triggers Docker publish with prerelease semantics.
+4. This workflow publishes a GitHub prerelease and triggers Docker publish with prerelease semantics.
 
 ## Guardrails
 
@@ -123,7 +130,7 @@ gh workflow run "Release (manual)" -f tag=YYYY.M.D-rc.N
 - Never interpret the final stable version segment as an incrementing monthly patch number; it is the calendar day of month for the release date.
 - Never use a non-CalVer stable version format in this repository unless the project convention is explicitly changed again.
 - Never add a `v` prefix to new release tags in this repository.
-- Never pretend a repository changelog exists for this project. Use the GitHub release page instead.
+- Never publish a release or prerelease without checking whether `CHANGELOG.md` needs a release rollover.
 - Never recreate an existing tag or GitHub release.
 - Never use the manual prerelease workflow for a normal stable release when direct GitHub release publication is intended.
 
@@ -141,8 +148,10 @@ Before finishing, verify all items:
 ## Related Files
 
 - `mix.exs`
+- `CHANGELOG.md`
 - `.github/workflows/release.yml`
 - `.github/workflows/release-manual.yml`
+- `.agents/skills/save-it-changelog/SKILL.md`
 - `.agents/skills/acceptance-testing/SKILL.md`
 
 ## Resources

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,4 @@ When solving a non-trivial bug or issue, create `others/postmortem/YYYY-MM-DD-ti
 - **Always** use fixed versions for dependencies.
 - Maintain a repository `CHANGELOG.md` using [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) structure.
 - Use CalVer release headings in `CHANGELOG.md`, for example `## [2026.6.9] - 2026-06-09`.
-- At the end of repository work, check `CHANGELOG.md` and update `## [Unreleased]` for notable user-facing, operational, documentation, workflow, or agent-process changes.
+- At the end of repository work, check `CHANGELOG.md` and update `## [Unreleased]` only for product-focused user-facing features, behavior changes, fixes, removals, security changes, or breaking changes. Do not record docs-only, tests-only, chore-only, formatting-only, CI-only, internal refactor-only, release-process-only, or agent-workflow-only changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Changed
+
+- Simplify photo details to show only the source message URL, original URL, and saved timestamp.
+
 ## [2026.6.12-rc.1] - 2026-06-12
 
 ### Added

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -562,7 +562,6 @@ defmodule SaveIt.Bot do
 
         bot_send_file(context.chat_id, downloaded_file, {:file, downloaded_file},
           source_url: context.original_url,
-          download_url: context.download_url,
           source_chat: context.chat,
           caption: download_caption(context)
         )
@@ -744,8 +743,7 @@ defmodule SaveIt.Bot do
       bot_send_media_group(
         chat_id,
         Enum.map(files, fn %DownloadedFile{} = file ->
-          {file.file_name, {:file_content, file.file_content, file.file_name}, source_url,
-           file.download_url}
+          {file.file_name, {:file_content, file.file_content, file.file_name}, source_url}
         end),
         source_chat: source_chat,
         caption: caption
@@ -766,7 +764,7 @@ defmodule SaveIt.Bot do
       chat_id,
       file.file_name,
       {:file_content, file.file_content, file.file_name},
-      Keyword.put_new(opts, :download_url, file.download_url)
+      opts
     )
   end
 
@@ -801,7 +799,7 @@ defmodule SaveIt.Bot do
       {:ok, messages} ->
         Enum.zip(files, messages)
         |> Enum.each(fn
-          {{_file_name, content, source_url, download_url}, msg} ->
+          {{_file_name, content, source_url, _download_url}, msg} ->
             file_id = get_file_id(msg)
             image_base64 = encode_file_content(content)
 
@@ -810,7 +808,6 @@ defmodule SaveIt.Bot do
               caption: caption,
               file_id: file_id,
               url: source_url,
-              download_url: download_url,
               belongs_to_id: chat_id
             }
             |> Map.merge(source_message_fields(source_chat, message_id(msg)))
@@ -848,10 +845,9 @@ defmodule SaveIt.Bot do
         Logger.error("Failed to send media group: #{inspect(reason)}")
 
         Enum.each(files, fn
-          {file_name, content, source_url, download_url} ->
+          {file_name, content, source_url, _download_url} ->
             bot_send_file(chat_id, file_name, content,
               source_url: source_url,
-              download_url: download_url,
               source_chat: source_chat,
               caption: caption
             )
@@ -878,7 +874,6 @@ defmodule SaveIt.Bot do
 
     caption = Keyword.get(opts, :caption, "")
     source_url = Keyword.get(opts, :source_url)
-    download_url = Keyword.get(opts, :download_url)
     source_chat = Keyword.get(opts, :source_chat) || %{id: chat_id}
 
     if telegram_upload_too_large?(content) do
@@ -888,7 +883,6 @@ defmodule SaveIt.Bot do
       do_bot_send_file(chat_id, file_name, content,
         caption: caption,
         source_url: source_url,
-        download_url: download_url,
         source_chat: source_chat
       )
     end
@@ -897,7 +891,6 @@ defmodule SaveIt.Bot do
   defp do_bot_send_file(chat_id, file_name, content, opts) do
     caption = Keyword.fetch!(opts, :caption)
     source_url = Keyword.get(opts, :source_url)
-    download_url = Keyword.get(opts, :download_url)
     source_chat = Keyword.fetch!(opts, :source_chat)
 
     case file_extension(file_name) do
@@ -914,7 +907,6 @@ defmodule SaveIt.Bot do
           caption: caption,
           file_id: file_id,
           url: source_url,
-          download_url: download_url,
           belongs_to_id: chat_id
         }
         |> Map.merge(source_message_fields(source_chat, message_id(msg)))
@@ -1130,18 +1122,15 @@ defmodule SaveIt.Bot do
         send_message(chat_id, "Photo details not found.")
 
       photo ->
-        send_message(chat_id, detail_message(reply_to_message, photo, file_id))
+        send_message(chat_id, detail_message(reply_to_message, photo))
     end
   end
 
-  defp detail_message(reply_to_message, photo, file_id) do
+  defp detail_message(reply_to_message, photo) do
     [
-      detail_line("Sent at", format_unix_time(Map.get(reply_to_message, :date))),
-      detail_line("Original URL", Map.get(photo, "url")),
-      detail_line("Download URL", Map.get(photo, "download_url")),
       detail_line("Message URL", Map.get(photo, "source_message_url")),
-      detail_line("File ID", file_id),
-      detail_line("Typesense ID", Map.get(photo, "id"))
+      detail_line("Original URL", Map.get(photo, "url")),
+      detail_line("Saved at", saved_at(photo, reply_to_message))
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join("\n")
@@ -1150,6 +1139,10 @@ defmodule SaveIt.Bot do
   defp detail_line(_label, nil), do: nil
   defp detail_line(_label, ""), do: nil
   defp detail_line(label, value), do: "#{label}: #{value}"
+
+  defp saved_at(photo, reply_to_message) do
+    format_unix_time(Map.get(photo, "inserted_at") || Map.get(reply_to_message, :date))
+  end
 
   defp format_unix_time(timestamp) when is_integer(timestamp) do
     timestamp

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -85,7 +85,7 @@ defmodule SaveIt.BotTest do
     document = Jason.decode!(typesense_body)
 
     assert document["url"] == original_url
-    assert document["download_url"] == download_url
+    refute Map.has_key?(document, "download_url")
     assert document["caption"] == "created at 2024-06-01"
     assert document["file_id"] == "telegram-photo-file-id"
     assert document["belongs_to_id"] == "12345"
@@ -262,15 +262,7 @@ defmodule SaveIt.BotTest do
 
     assert Enum.map(documents, & &1["url"]) == List.duplicate(original_url, 4)
     assert Enum.map(documents, & &1["caption"]) == List.duplicate("created at 2024-06-01", 4)
-
-    assert Enum.map(documents, & &1["download_url"]) |> Enum.sort() ==
-             [
-               "#{base_test_server_url()}/downloaded/photo-1.jpg",
-               "#{base_test_server_url()}/downloaded/photo-2.jpg",
-               "#{base_test_server_url()}/downloaded/photo-3.jpg",
-               "#{base_test_server_url()}/downloaded/photo-4.jpg"
-             ]
-             |> Enum.sort()
+    refute Enum.any?(documents, &Map.has_key?(&1, "download_url"))
 
     assert Enum.map(documents, & &1["file_id"]) == [
              "group-file-1",
@@ -631,7 +623,6 @@ defmodule SaveIt.BotTest do
 
     chat_id = 12_345
     original_url = "https://x.com/example/status/1?utm_source=telegram"
-    download_url = "#{base_test_server_url()}/downloaded/photo.jpg"
 
     message = %{
       chat: %{id: chat_id},
@@ -654,11 +645,16 @@ defmodule SaveIt.BotTest do
     request_body = sent_message_body()
 
     assert request_body.chat_id == chat_id
-    assert request_body.text =~ "Sent at: 2024-06-01 00:00:00 UTC"
-    assert request_body.text =~ "Original URL: #{original_url}"
-    assert request_body.text =~ "Download URL: #{download_url}"
-    assert request_body.text =~ "Message URL: https://t.me/save_it_test_chat/20"
-    assert request_body.text =~ "File ID: telegram-photo-file-id"
+
+    assert request_body.text ==
+             Enum.join(
+               [
+                 "Message URL: https://t.me/save_it_test_chat/20",
+                 "Original URL: #{original_url}",
+                 "Saved at: 2024-06-01 00:00:00 UTC"
+               ],
+               "\n"
+             )
   end
 
   test "omits missing values from photo details", _context do
@@ -684,9 +680,11 @@ defmodule SaveIt.BotTest do
     request_body = sent_message_body()
 
     assert request_body.chat_id == chat_id
-    assert request_body.text == "File ID: old-photo-file-id\nTypesense ID: old-typesense-photo-id"
+    assert request_body.text == "Saved at: 2024-06-01 00:00:00 UTC"
     refute request_body.text =~ "N/A"
     refute request_body.text =~ "Sent at:"
+    refute request_body.text =~ "File ID:"
+    refute request_body.text =~ "Typesense ID:"
     refute request_body.text =~ "Original URL:"
     refute request_body.text =~ "Download URL:"
     refute request_body.text =~ "Message URL:"
@@ -699,10 +697,6 @@ defmodule SaveIt.BotTest do
 
     File.rm(url_cache_path)
     File.rm(file_path)
-  end
-
-  defp base_test_server_url do
-    Application.fetch_env!(:save_it, :typesense_url)
   end
 
   defp sent_message_body do


### PR DESCRIPTION
## Summary

- Simplify `/detail` output to only show message URL, original URL, and saved timestamp.
- Stop storing Cobalt/media direct download URLs in indexed photo metadata.
- Update changelog guidance so changelog entries stay product-focused and skip docs/test/chore-only changes.

## Validation

- `mix test`
- `mix format --check-formatted lib/save_it/bot.ex test/bot_test.exs CHANGELOG.md .agents/skills/save-it-changelog/SKILL.md .agents/skills/save-it-release/SKILL.md AGENTS.md`
- `quick_validate.py` for `save-it-changelog`, `changelog`, and `save-it-release` skills

## Notes

The user-level `~/.agents/skills/changelog` skill was updated locally as requested, but it lives outside this repository and is not part of this PR.
