### PR TITLE
fix: tighten runtime logging config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ before the CalVer migration retain their original version labels.
 
 - Simplify photo details to show only the source message URL, original URL, and saved timestamp.
 - Keep HTTP logs at request-summary level instead of dumping full request and response bodies at debug level.
-- Require `TELEGRAM_BOT_TOKEN` at runtime outside the test environment.
 
 ## [2026.6.12-rc.1] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ before the CalVer migration retain their original version labels.
 ### Changed
 
 - Simplify photo details to show only the source message URL, original URL, and saved timestamp.
+- Keep HTTP logs at request-summary level instead of dumping full request and response bodies at debug level.
+- Require `TELEGRAM_BOT_TOKEN` at runtime outside the test environment.
 
 ## [2026.6.12-rc.1] - 2026-06-12
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,7 @@ config :logger, level: :info
 
 config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
-  metadata: [],
+  metadata: [:status, :file_id, :kind],
   colors: [
     enabled: true,
     debug: :cyan,

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,6 +4,8 @@ config :tesla, :adapter, Tesla.Adapter.Hackney
 
 config :tesla, Tesla.Middleware.Logger, debug: false
 
+config :logger, level: :info
+
 config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
   metadata: [],

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,16 @@
 import Config
 
 config :tesla, :adapter, Tesla.Adapter.Hackney
+
+config :tesla, Tesla.Middleware.Logger, debug: false
+
+config :logger, :default_formatter,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [],
+  colors: [
+    enabled: true,
+    debug: :cyan,
+    info: :green,
+    warning: :yellow,
+    error: :red
+  ]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -2,24 +2,20 @@ import Config
 
 config :save_it, :timezone, System.get_env("TZ") || "Asia/Tokyo"
 
-config :save_it, :telegram_bot_token, System.get_env("TELEGRAM_BOT_TOKEN")
-config :ex_gram, token: System.get_env("TELEGRAM_BOT_TOKEN")
+telegram_bot_token =
+  if config_env() == :test do
+    System.get_env("TELEGRAM_BOT_TOKEN", "test-token")
+  else
+    System.fetch_env!("TELEGRAM_BOT_TOKEN")
+  end
+
+config :save_it, :telegram_bot_token, telegram_bot_token
+config :ex_gram, token: telegram_bot_token
 
 config :save_it, :cobalt_api_url, System.get_env("COBALT_API_URL", "http://localhost:9001")
 
 config :save_it, :typesense_url, System.get_env("TYPESENSE_URL", "http://localhost:8108")
 config :save_it, :typesense_api_key, System.get_env("TYPESENSE_API_KEY", "xyz")
-
-config :logger, :default_formatter,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [],
-  colors: [
-    enabled: true,
-    debug: :cyan,
-    info: :green,
-    warning: :yellow,
-    error: :red
-  ]
 
 # optional
 config :save_it, :google_oauth_client_id, System.get_env("GOOGLE_OAUTH_CLIENT_ID")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -2,12 +2,7 @@ import Config
 
 config :save_it, :timezone, System.get_env("TZ") || "Asia/Tokyo"
 
-telegram_bot_token =
-  if config_env() == :test do
-    System.get_env("TELEGRAM_BOT_TOKEN", "test-token")
-  else
-    System.fetch_env!("TELEGRAM_BOT_TOKEN")
-  end
+telegram_bot_token = System.get_env("TELEGRAM_BOT_TOKEN")
 
 config :save_it, :telegram_bot_token, telegram_bot_token
 config :ex_gram, token: telegram_bot_token

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -87,8 +87,8 @@ defmodule SaveIt.Bot do
         Run `/login` after you have logged in.
         """)
 
-      {:error, error} ->
-        Logger.error("Failed to get device code: #{inspect(error)}")
+      {:error, _error} ->
+        Logger.error("Failed to get device code")
         send_message(chat.id, "Failed to get device code")
     end
   end
@@ -252,9 +252,10 @@ defmodule SaveIt.Bot do
       {:ok, _response} ->
         :ok
 
-      {:error, reason} ->
+      {:error, _reason} ->
         Logger.warning(
-          "Failed to send similar media group, falling back to individual media: #{inspect(reason)}"
+          "Failed to send similar media group, falling back to individual media",
+          kind: :telegram_media_group_failed
         )
 
         Enum.each(similar_photos, &send_similar_media(chat_id, &1))
@@ -267,9 +268,10 @@ defmodule SaveIt.Bot do
       {:ok, _response} ->
         :ok
 
-      {:error, reason} ->
+      {:error, _reason} ->
         Logger.warning(
-          "Skipping unavailable similar media file_id=#{inspect(media["file_id"])}: #{inspect(reason)}"
+          "Skipping unavailable similar media",
+          file_id: media["file_id"]
         )
 
         :error
@@ -361,8 +363,8 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp handle_uploaded_video_file_error(reason) do
-    Logger.warning("Skipping local backup for Telegram video: #{inspect(reason)}")
+  defp handle_uploaded_video_file_error(_reason) do
+    Logger.warning("Skipping local backup for Telegram video")
     :error
   end
 
@@ -591,12 +593,10 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp handle_download_failure(%DownloadContext{} = context, failure_message, failure_reason) do
+  defp handle_download_failure(%DownloadContext{} = context, failure_message, _failure_reason) do
     case download_message_thumbnail(context.message) do
       {:ok, %DownloadedFile{} = file} ->
-        Logger.warning(
-          "Saved Telegram thumbnail fallback after link download failed: #{inspect(failure_reason)}"
-        )
+        Logger.warning("Saved Telegram thumbnail fallback after link download failed")
 
         update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
 
@@ -608,11 +608,8 @@ defmodule SaveIt.Bot do
 
         finalize_thumbnail_download(context, file)
 
-      {:error, fallback_reason} ->
-        Logger.warning(
-          "No Telegram thumbnail fallback available after link download failed: " <>
-            "failure_reason=#{inspect(failure_reason)} fallback_reason=#{inspect(fallback_reason)}"
-        )
+      {:error, _fallback_reason} ->
+        Logger.warning("No Telegram thumbnail fallback available after link download failed")
 
         update_message(context.chat_id, context.progress_message_id, failure_message)
         :error
@@ -841,8 +838,8 @@ defmodule SaveIt.Bot do
             |> PhotoService.create_photo!()
         end)
 
-      {:error, reason} ->
-        Logger.error("Failed to send media group: #{inspect(reason)}")
+      {:error, _reason} ->
+        Logger.error("Failed to send media group")
 
         Enum.each(files, fn
           {file_name, content, source_url, _download_url} ->
@@ -1047,8 +1044,8 @@ defmodule SaveIt.Bot do
       Logger.error("Typesense create_photo failed: #{Exception.message(error)}")
       nil
   catch
-    kind, reason ->
-      Logger.error("Typesense create_photo failed: #{inspect({kind, reason})}")
+    kind, _reason ->
+      Logger.error("Typesense create_photo failed", kind: kind)
       nil
   end
 
@@ -1059,8 +1056,8 @@ defmodule SaveIt.Bot do
       Logger.error("Typesense search_photos failed: #{Exception.message(error)}")
       []
   catch
-    kind, reason ->
-      Logger.error("Typesense search_photos failed: #{inspect({kind, reason})}")
+    kind, _reason ->
+      Logger.error("Typesense search_photos failed", kind: kind)
       []
   end
 
@@ -1071,8 +1068,8 @@ defmodule SaveIt.Bot do
       Logger.error("Typesense search_similar_photos failed: #{Exception.message(error)}")
       []
   catch
-    kind, reason ->
-      Logger.error("Typesense search_similar_photos failed: #{inspect({kind, reason})}")
+    kind, _reason ->
+      Logger.error("Typesense search_similar_photos failed", kind: kind)
       []
   end
 
@@ -1084,8 +1081,8 @@ defmodule SaveIt.Bot do
         FileHelper.set_google_access_token(chat.id, body["access_token"])
         send_message(chat.id, "Successfully logged in!")
 
-      {:error, error} ->
-        Logger.error("Failed to log in: #{inspect(error)}")
+      {:error, _error} ->
+        Logger.error("Failed to log in")
 
         send_message(chat.id, """
         Failed to log in.
@@ -1159,8 +1156,8 @@ defmodule SaveIt.Bot do
       Logger.error("Typesense get_photo failed: #{Exception.message(error)}")
       nil
   catch
-    kind, reason ->
-      Logger.error("Typesense get_photo failed: #{inspect({kind, reason})}")
+    kind, _reason ->
+      Logger.error("Typesense get_photo failed", kind: kind)
       nil
   end
 end

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -611,7 +611,7 @@ defmodule SaveIt.Bot do
       {:error, fallback_reason} ->
         Logger.warning(
           "No Telegram thumbnail fallback available after link download failed: " <>
-            inspect(%{failure_reason: failure_reason, fallback_reason: fallback_reason})
+            "failure_reason=#{inspect(failure_reason)} fallback_reason=#{inspect(fallback_reason)}"
         )
 
         update_message(context.chat_id, context.progress_message_id, failure_message)

--- a/lib/save_it/google_drive.ex
+++ b/lib/save_it/google_drive.ex
@@ -160,12 +160,12 @@ defmodule SaveIt.GoogleDrive do
   end
 
   defp handle_response({:ok, %{status: status, body: body}}) do
-    Logger.warning("Failed at Google Drive, status: #{status}, body: #{inspect(body)}")
+    Logger.warning("Failed at Google Drive", status: status)
     {:error, %{status: status, body: body}}
   end
 
   defp handle_response({:error, reason}) do
-    Logger.error("Failed at Google Drive, reason: #{inspect(reason)}")
+    Logger.error("Failed at Google Drive")
     {:error, reason}
   end
 end

--- a/lib/save_it/google_oauth2_device_flow.ex
+++ b/lib/save_it/google_oauth2_device_flow.ex
@@ -28,12 +28,12 @@ defmodule SaveIt.GoogleOAuth2DeviceFlow do
   end
 
   defp handle_response({:ok, %Tesla.Env{status: status, body: body}}) do
-    Logger.warning("handle_response, status: #{status}, body: #{inspect(body)}")
+    Logger.warning("Google OAuth request failed", status: status)
     {:error, %{status: status, body: body}}
   end
 
   defp handle_response({:error, reason}) do
-    Logger.error("handle_response, reason: #{inspect(reason)}")
+    Logger.error("Google OAuth request failed")
     {:error, reason}
   end
 

--- a/lib/save_it/photo_service.ex
+++ b/lib/save_it/photo_service.ex
@@ -169,13 +169,24 @@ defmodule SaveIt.PhotoService do
 
     Logger.info(
       "Typesense #{action} response: " <>
-        inspect(%{
-          metadata: metadata,
-          hits_count: hits_count,
-          top_vector_distances: top_vector_distances,
-          results: results
-        })
+        "metadata=#{format_log_fields(metadata)} " <>
+        "hits_count=#{hits_count} " <>
+        "top_vector_distances=#{format_log_list(top_vector_distances)} " <>
+        "results_count=#{length(results)}"
     )
+  end
+
+  defp format_log_fields(fields) do
+    fields
+    |> Enum.map(fn {key, value} -> "#{key}=#{inspect(value)}" end)
+    |> Enum.join(" ")
+  end
+
+  defp format_log_list(values) do
+    values
+    |> Enum.map(&inspect/1)
+    |> Enum.join(", ")
+    |> then(&"[#{&1}]")
   end
 
   defp normalize_photo_urls(photo_params) do

--- a/lib/small_sdk/bad_news.ex
+++ b/lib/small_sdk/bad_news.ex
@@ -23,8 +23,8 @@ defmodule SmallSdk.BadNews do
       {:ok, %{status: status}} ->
         {:error, "bad.news returned status #{status}"}
 
-      {:error, reason} ->
-        Logger.error("Failed to fetch bad.news page: #{inspect(reason)}")
+      {:error, _reason} ->
+        Logger.error("Failed to fetch bad.news page")
         {:error, "Failed to fetch bad.news page"}
     end
   end

--- a/lib/small_sdk/cobalt.ex
+++ b/lib/small_sdk/cobalt.ex
@@ -22,7 +22,7 @@ defmodule SmallSdk.Cobalt do
         {:ok, url, Enum.map(picker_items, &Map.get(&1, "url"))}
 
       {:ok, _} ->
-        Logger.warning("cobalt response: #{inspect(res)}")
+        Logger.warning("Unexpected cobalt response")
         {:error, "Can't get download url using Cobalt API"}
 
       {:error, msg} ->
@@ -75,13 +75,13 @@ defmodule SmallSdk.Cobalt do
         {:ok, body}
 
       _ ->
-        {:error, "Request failed with status #{status}: #{inspect(body)}"}
+        {:error, "Request failed with status #{status}"}
     end
   end
 
-  def handle_response({:error, reason}) do
-    Logger.error("Request failed: #{inspect(reason)}")
-    {:error, "Request failed: #{inspect(reason)}"}
+  def handle_response({:error, _reason}) do
+    Logger.error("Request failed")
+    {:error, "Request failed"}
   end
 
   def handle_response!(%{status: status, body: body}) do
@@ -90,7 +90,7 @@ defmodule SmallSdk.Cobalt do
         body
 
       status ->
-        Logger.error("Request failed with status #{status}: #{inspect(body)}")
+        Logger.error("Request failed", status: status)
         raise "Request failed with status #{status}"
     end
   end

--- a/lib/small_sdk/hls_downloader.ex
+++ b/lib/small_sdk/hls_downloader.ex
@@ -63,8 +63,8 @@ defmodule SmallSdk.HlsDownloader do
           download_best_variant(rest, original_url)
       end
     rescue
-      e in ErlangError ->
-        Logger.error("ffmpeg not found: #{inspect(e)}")
+      _e in ErlangError ->
+        Logger.error("ffmpeg not found")
         {:error, "ffmpeg is not installed"}
     after
       File.rm(tmp_path)

--- a/lib/small_sdk/typesense.ex
+++ b/lib/small_sdk/typesense.ex
@@ -182,7 +182,7 @@ defmodule SmallSdk.Typesense do
         body
 
       400 ->
-        Logger.warning("Bad Request: #{inspect(body)}")
+        Logger.warning("Bad Typesense request", status: 400)
         raise "Bad Request"
 
       401 ->
@@ -202,13 +202,13 @@ defmodule SmallSdk.Typesense do
         raise "Service Unavailable"
 
       _ ->
-        Logger.error("Unhandled status code #{status}: #{inspect(body)}")
+        Logger.error("Unhandled Typesense response", status: status)
         raise "Unknown error: #{status}"
     end
   end
 
-  def handle_response({:error, reason}) do
-    Logger.error("Request failed: #{inspect(reason)}")
+  def handle_response({:error, _reason}) do
+    Logger.error("Typesense request failed")
     raise "Request failed"
   end
 
@@ -218,7 +218,7 @@ defmodule SmallSdk.Typesense do
         body
 
       status ->
-        Logger.warning("Request failed with status #{status}: #{inspect(body)}")
+        Logger.warning("Typesense request failed", status: status)
         raise "Request failed with status #{status}"
     end
   end

--- a/lib/small_sdk/web_downloader.ex
+++ b/lib/small_sdk/web_downloader.ex
@@ -42,12 +42,12 @@ defmodule SmallSdk.WebDownloader do
            download_url: url
          }}
 
-      {:ok, %{status: status, body: body}} ->
-        Logger.error("download_file failed, status: #{status}, body: #{inspect(body)}")
+      {:ok, %{status: status, body: _body}} ->
+        Logger.error("download_file failed", status: status)
         {:error, "💔 Failed to download file"}
 
-      {:error, reason} ->
-        Logger.error("download_file failed, reason: #{inspect(reason)}")
+      {:error, _reason} ->
+        Logger.error("download_file failed")
         {:error, "💔 Failed to download file"}
     end
   end

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -565,7 +565,7 @@ defmodule SaveIt.BotTest do
     assert document["image"] == Base.encode64(test_jpeg())
 
     assert log =~ "Skipping local backup for Telegram video"
-    assert log =~ "file is too big"
+    refute log =~ ~s({"ok":false)
     refute_receive {:exgram_request, :post, "/bottest-token/sendMessage", %{chat_id: ^chat_id}}
     refute_receive {:google_drive_upload_request, _drive_env}
   end
@@ -612,7 +612,7 @@ defmodule SaveIt.BotTest do
     assert document["image"] == Base.encode64(test_jpeg())
 
     assert log =~ "Skipping local backup for Telegram video"
-    assert log =~ ":timeout"
+    refute log =~ ":timeout"
     refute_receive {:exgram_request, :post, "/bottest-token/sendMessage", %{chat_id: ^chat_id}}
     refute File.exists?(stored_file_path)
     refute_receive {:google_drive_upload_request, _drive_env}

--- a/test/cobalt_test.exs
+++ b/test/cobalt_test.exs
@@ -24,14 +24,15 @@ defmodule SmallSdk.CobaltTest do
 
     assert {:error, msg} = Cobalt.handle_response(response)
     assert msg =~ "Request failed with status 500"
+    refute msg =~ "internal"
+    refute msg =~ "%{"
   end
 
   test "handle_response/1 does not raise on transport error" do
     response = {:error, %Req.TransportError{reason: :econnrefused}}
 
     assert {:error, msg} = Cobalt.handle_response(response)
-    assert msg =~ "Request failed"
-    assert msg =~ "econnrefused"
+    assert msg == "Request failed"
   end
 
   test "get_download_url/1 rewrites tunnel urls to the configured cobalt api host" do

--- a/test/logger_config_test.exs
+++ b/test/logger_config_test.exs
@@ -39,6 +39,7 @@ defmodule SaveIt.LoggerConfigTest do
 
     logger_config = Application.fetch_env!(:logger, :default_formatter)
 
+    assert logger_config[:metadata] == [:status, :file_id, :kind]
     assert logger_config[:colors][:info] == :green
     assert logger_config[:colors][:warning] == :yellow
     assert logger_config[:colors][:error] == :red

--- a/test/logger_config_test.exs
+++ b/test/logger_config_test.exs
@@ -1,0 +1,72 @@
+defmodule SaveIt.LoggerConfigTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  @tesla_logger_config Application.compile_env(:tesla, Tesla.Middleware.Logger, [])
+  @runtime_config Path.expand("../config/runtime.exs", __DIR__)
+
+  defmodule TeslaTestAdapter do
+    @behaviour Tesla.Adapter
+
+    @impl Tesla.Adapter
+    def call(%Tesla.Env{} = env, _opts) do
+      {:ok, %Tesla.Env{env | status: 200, body: %{ok: true, result: %{created: 1}}}}
+    end
+  end
+
+  test "Tesla HTTP logger does not dump full request and response bodies at debug level" do
+    assert @tesla_logger_config[:debug] == false
+  end
+
+  test "Tesla HTTP logger keeps debug output at request summary level" do
+    log =
+      capture_log([level: :debug], fn ->
+        client = Tesla.client([{Tesla.Middleware.Logger, []}], TeslaTestAdapter)
+
+        assert {:ok, %Tesla.Env{status: 200}} =
+                 Tesla.post(client, "https://example.test/save", %{message_id: 3974})
+      end)
+
+    assert log =~ "POST https://example.test/save -> 200"
+    refute log =~ ">>> REQUEST >>>"
+    refute log =~ "%{message_id: 3974}"
+    refute log =~ "%{ok: true"
+  end
+
+  test "runtime logger uses distinct severity colors" do
+    logger_config = Application.fetch_env!(:logger, :default_formatter)
+
+    assert logger_config[:colors][:info] == :green
+    assert logger_config[:colors][:warning] == :yellow
+    assert logger_config[:colors][:error] == :red
+  end
+
+  test "runtime config requires the Telegram bot token and shares it with ExGram" do
+    previous_system_token = System.get_env("TELEGRAM_BOT_TOKEN")
+
+    on_exit(fn ->
+      restore_system_env("TELEGRAM_BOT_TOKEN", previous_system_token)
+    end)
+
+    System.put_env("TELEGRAM_BOT_TOKEN", "required-token")
+    runtime_config = Config.Reader.read!(@runtime_config, env: Mix.env())
+
+    assert get_in(runtime_config, [:save_it, :telegram_bot_token]) == "required-token"
+    assert get_in(runtime_config, [:ex_gram, :token]) == "required-token"
+
+    System.delete_env("TELEGRAM_BOT_TOKEN")
+
+    test_runtime_config = Config.Reader.read!(@runtime_config, env: :test)
+
+    assert get_in(test_runtime_config, [:save_it, :telegram_bot_token]) == "test-token"
+    assert get_in(test_runtime_config, [:ex_gram, :token]) == "test-token"
+
+    assert_raise System.EnvError, fn ->
+      Config.Reader.read!(@runtime_config, env: :dev)
+    end
+  end
+
+  defp restore_system_env(key, nil), do: System.delete_env(key)
+  defp restore_system_env(key, value), do: System.put_env(key, value)
+end

--- a/test/logger_config_test.exs
+++ b/test/logger_config_test.exs
@@ -35,6 +35,8 @@ defmodule SaveIt.LoggerConfigTest do
   end
 
   test "runtime logger uses distinct severity colors" do
+    assert Application.fetch_env!(:logger, :level) == :info
+
     logger_config = Application.fetch_env!(:logger, :default_formatter)
 
     assert logger_config[:colors][:info] == :green

--- a/test/logger_config_test.exs
+++ b/test/logger_config_test.exs
@@ -42,7 +42,7 @@ defmodule SaveIt.LoggerConfigTest do
     assert logger_config[:colors][:error] == :red
   end
 
-  test "runtime config requires the Telegram bot token and shares it with ExGram" do
+  test "runtime config shares the Telegram bot token with ExGram" do
     previous_system_token = System.get_env("TELEGRAM_BOT_TOKEN")
 
     on_exit(fn ->
@@ -54,17 +54,6 @@ defmodule SaveIt.LoggerConfigTest do
 
     assert get_in(runtime_config, [:save_it, :telegram_bot_token]) == "required-token"
     assert get_in(runtime_config, [:ex_gram, :token]) == "required-token"
-
-    System.delete_env("TELEGRAM_BOT_TOKEN")
-
-    test_runtime_config = Config.Reader.read!(@runtime_config, env: :test)
-
-    assert get_in(test_runtime_config, [:save_it, :telegram_bot_token]) == "test-token"
-    assert get_in(test_runtime_config, [:ex_gram, :token]) == "test-token"
-
-    assert_raise System.EnvError, fn ->
-      Config.Reader.read!(@runtime_config, env: :dev)
-    end
   end
 
   defp restore_system_env(key, nil), do: System.delete_env(key)


### PR DESCRIPTION
## Summary

- disable Tesla's detailed debug request/response body dump and set the default logger level to `:info`
- move static logger formatter color configuration into `config/config.exs`
- read `TELEGRAM_BOT_TOKEN` once in runtime config and reuse it for both `:save_it` and `:ex_gram`
- replace raw JSON/body/struct-style production logs with standard Logger messages plus small metadata (`status`, `file_id`, `kind`)
- add config and regression tests covering log behavior, severity colors, and shared Telegram token config
- resolve conflicts with `main` while preserving the URL preview thumbnail fallback behavior without reintroducing raw `inspect` logs

## Validation

- `mix test test/logger_config_test.exs test/cobalt_test.exs test/bot_test.exs test/small_sdk/link_preview_test.exs`
- `mix compile --warnings-as-errors`
- `rg -n "\\bIO\\.(puts|inspect|write|warn)\\b|\\bdbg\\b|Logger\\.(debug|info|warning|warn|error)\\([^\\n]*inspect\\(|body: #\\{inspect|response: #\\{inspect|status: #\\{status\\}, body|%ExGram\\.Error|%Req\\.TransportError|\\{\\\"ok\\\":false" lib config priv`
- `git diff --check`
