### PR TITLE
fix: preserve Telegram video metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve downloaded MP4 video display dimensions when sending to Telegram, and prepare uploads for streaming playback when possible.
+
 ## [2026.6.13] - 2026-06-13
 
 ### Changed

--- a/docs/blog/en/2026-06-13-telegram-video-metadata.md
+++ b/docs/blog/en/2026-06-13-telegram-video-metadata.md
@@ -1,0 +1,123 @@
+# The MP4 Metadata Bug Hiding Behind a Telegram Bot Upload
+
+2026-06-13
+
+Some bugs are valuable not because the patch is large, but because they expose a boundary we had been treating as simpler than it really was.
+
+This one started with a strange symptom in save_it: a video downloaded by the bot and sent to Telegram would sometimes appear with the wrong aspect ratio. The original file was fine. If the same file was downloaded manually and uploaded through a Telegram client, it displayed correctly. Large videos also did not always behave like streamable Telegram videos; they were less likely to start loading automatically.
+
+The obvious question was: is this a Telegram Bot API limitation, or an ex_gram limitation?
+
+The answer turned out to be: partly yes, but not in the way that first appeared.
+
+## The misleading part
+
+When the original file displays correctly and a manual Telegram upload displays correctly, it is tempting to assume the bot API is damaging the video. But the upload path matters.
+
+A Telegram client can inspect and prepare a video before upload. A bot upload is much more explicit: the bot sends a file and a set of parameters, and Telegram makes a decision from those inputs. ex_gram is mostly a wrapper around that API. If we do not provide width, height, duration, or a stream-friendly MP4 structure, ex_gram will not invent that information for us.
+
+The issue was not that ex_gram sent correct metadata incorrectly. The issue was that save_it was not sending enough metadata in the first place.
+
+## `supports_streaming` is necessary, not sufficient
+
+Telegram Bot API's `sendVideo` method supports video `duration`, `width`, `height`, and `supports_streaming`. The same official documentation says regular Bot API video uploads are currently limited to 50 MB. If you switch to a Local Bot API Server, uploads can go up to 2000 MB.
+
+That explains two separate things:
+
+- Large videos really do run into a Bot API boundary when using the normal hosted API.
+- `supports_streaming: true` is only a signal that the uploaded video is suitable for streaming. It does not guarantee every Telegram client will eagerly load every uploaded MP4.
+
+Streaming behavior also depends on the MP4 container itself. An MP4 can be perfectly playable while still being poorly arranged for progressive playback. If the `moov` atom is near the end of the file, a client may need more of the file before it can start playback. For bot uploads, it is safer to prepare the file as faststart-compatible before sending it.
+
+## Aspect ratio is display metadata, not just pixels
+
+The aspect ratio bug came from another subtle media detail: encoded dimensions and display dimensions are not always the same thing.
+
+Phone videos are a common example. A vertical video may be encoded with one width and height, then carry rotation metadata that tells players how to display it. A local player reads that metadata and shows the video correctly. A Telegram client upload may also normalize or preserve that display intent during upload.
+
+But if the bot sends only the raw file and `supports_streaming: true`, Telegram may infer dimensions from the upload differently. For videos with rotation metadata, that can produce a wrong display ratio.
+
+The fix was to stop making Telegram guess. save_it now reads the video metadata itself and sends explicit display dimensions to `sendVideo`.
+
+## The fix
+
+The upload path now has a small preparation step for MP4 files.
+
+First, save_it tries to remux the video without re-encoding:
+
+```sh
+ffmpeg -c copy -movflags +faststart
+```
+
+This keeps the media streams intact while making the MP4 container friendlier for progressive playback. It avoids the cost and risk of transcoding: no quality loss, no codec decisions, no long CPU-heavy conversion step.
+
+Second, save_it probes the video with `ffprobe` and extracts:
+
+- width
+- height
+- duration
+- rotation metadata
+
+If the rotation is 90 or 270 degrees, the code swaps width and height to get the display dimensions rather than the raw encoded dimensions.
+
+Then `sendVideo` receives the important values explicitly:
+
+```elixir
+[
+  supports_streaming: true,
+  width: display_width,
+  height: display_height,
+  duration: duration
+]
+```
+
+The fallback behavior matters just as much as the happy path:
+
+- If faststart remuxing succeeds but probing fails, save_it still sends the prepared video without dimensions.
+- If remuxing fails, save_it falls back to the original file and still tries to probe it.
+- If both ffmpeg and ffprobe fail, the bot sends the original file using the previous behavior.
+
+That keeps the user experience resilient. A media metadata failure should not prevent the user from receiving the video.
+
+## Why this issue was worth fixing
+
+The valuable lesson is that the Telegram Bot API is not the Telegram client.
+
+When a user manually uploads a video, the client may do hidden work: inspect metadata, normalize the container, preserve rotation, or prepare the upload in a way Telegram understands well. A bot does not automatically get all of that. If we want reliable media behavior, the bot needs to be explicit.
+
+The save_it video flow is now clearer:
+
+1. Download the MP4.
+2. Try to make it faststart-friendly.
+3. Read display dimensions and duration.
+4. Send those values to Telegram.
+5. Fall back gracefully if media preparation fails.
+
+This separates three concerns that were previously blurred together:
+
+- API limits, such as the regular Bot API's 50 MB upload limit.
+- Container structure, such as whether the MP4 is suitable for progressive playback.
+- Display metadata, such as rotation and the difference between encoded dimensions and display dimensions.
+
+Once those concerns were separated, the fix became straightforward.
+
+## Reusable takeaways
+
+If you send videos through the Telegram Bot API, these are the rules I would keep:
+
+- Design regular Bot API uploads around the 50 MB limit.
+- Consider a Local Bot API Server if larger uploads are a real product requirement.
+- Pass `supports_streaming`, but do not treat it as an autoplay guarantee.
+- Make MP4 uploads faststart-friendly when possible.
+- Read display dimensions, not just encoded dimensions.
+- Pass width, height, and duration explicitly when the API supports them.
+- Treat media preparation as best-effort; failing to optimize should not fail the whole user request.
+
+The final patch was not about finding a magic Telegram parameter. It was about respecting the difference between “this file can be played” and “this file has been prepared and described well enough for a bot upload pipeline.”
+
+That distinction is easy to miss. It is also exactly where many useful engineering fixes live.
+
+## References
+
+- [Telegram Bot API: sendVideo](https://core.telegram.org/bots/api#sendvideo)
+- [Telegram Bot API: Using a Local Bot API Server](https://core.telegram.org/bots/api#using-a-local-bot-api-server)

--- a/docs/blog/zh/2026-06-13-telegram-video-metadata.md
+++ b/docs/blog/zh/2026-06-13-telegram-video-metadata.md
@@ -1,0 +1,120 @@
+# 一次 Telegram 视频比例错误背后的媒体元数据课
+
+2026-06-13
+
+有些 bug 的价值不在于改了多少代码，而在于它迫使我们把一个平时“差不多能用”的抽象重新看清楚。
+
+这次的问题看起来很具体：通过 save_it 下载并用 bot 发到 Telegram 的视频，有时候横纵比不正确；但同一个原始文件，手动下载以后再手动上传到 Telegram，比例又是对的。另一个相邻现象是，大一点的视频似乎也不太会自动加载，体验不像 Telegram 客户端里正常发送的视频。
+
+第一反应很自然：这是 Telegram Bot API 或 ex_gram 的限制吗？
+
+答案是：一部分是限制，一部分不是。
+
+## 现象为什么迷惑
+
+如果原始文件是正确的，手动上传也是正确的，那么“文件坏了”基本可以排除。剩下的怀疑对象通常有三个：
+
+- Telegram Bot API 对视频做了不同处理。
+- ex_gram 上传时丢了什么参数。
+- 我们下载到的 MP4 虽然能播放，但容器元数据不够适合 bot 上传。
+
+真正容易误判的是第二点。ex_gram 只是把我们传给它的参数发给 Telegram；如果我们只传了视频文件和 `supports_streaming: true`，它不会凭空知道视频的展示宽高、旋转信息、时长，或者帮我们重排 MP4 容器结构。
+
+也就是说，问题不在“ex_gram 把正确的信息发错了”，而在“我们根本没有把 Telegram 需要的展示信息显式交出去”。
+
+## `supports_streaming` 不是魔法开关
+
+Telegram Bot API 的 `sendVideo` 支持 `duration`、`width`、`height` 和 `supports_streaming`。官方文档也明确说，普通 Bot API 上传视频目前有 50 MB 限制；如果使用 Local Bot API Server，上传上限可以到 2000 MB。
+
+这解释了两个现象：
+
+- 对于大视频，普通 Bot API 的 50 MB 限制是真限制，不是代码里一个参数就能绕过去。
+- `supports_streaming: true` 只是告诉 Telegram“这个上传的视频适合流式播放”，它不等于“Telegram 一定会自动加载并按预期处理所有 MP4”。
+
+MP4 是否适合流式播放，还和文件内部的 `moov` atom 位置有关。很多网页下载下来的 MP4 可以正常播放，但 `moov` 信息可能在文件末尾。浏览器或本地播放器可以容忍这个结构；但如果我们希望客户端更快拿到索引信息，就应该让 MP4 变成 faststart 形式。
+
+## 比例错误的关键：展示尺寸不是编码尺寸
+
+视频文件里有一个很容易被忽略的细节：编码宽高和展示宽高不一定相同。
+
+常见例子是手机竖屏视频。它可能以横向尺寸编码，同时在 metadata 里写了 rotation。播放器读取 rotation 后会按竖屏展示，所以你看起来觉得“原始文件比例正确”。但如果某个上传链路没有把这个展示意图传递好，接收端就可能按原始编码宽高推断，结果视频被横着展示或比例异常。
+
+手动上传时，Telegram 客户端很可能会做一次本地分析或处理，把视频变成 Telegram 更容易理解的形式。而 bot 上传没有这层客户端帮忙，服务端只能根据我们提供的文件和参数做判断。
+
+这就是这次修复的核心：不要让 Telegram 猜。我们自己读出视频的展示尺寸，再明确传给 `sendVideo`。
+
+## 修复策略
+
+最终修复分成两步。
+
+第一步，上传前尝试无转码重封装：
+
+```sh
+ffmpeg -c copy -movflags +faststart
+```
+
+这里没有重新编码视频，只是尽量把 MP4 容器整理成更适合流式播放的结构。这样做成本低，也避免引入转码带来的画质、耗时和 CPU 问题。
+
+第二步，用 `ffprobe` 读取视频元数据：
+
+- `width`
+- `height`
+- `duration`
+- `rotation`
+
+如果 rotation 是 90 或 270 度，就交换宽高，把编码尺寸转换成展示尺寸。然后调用 Telegram `sendVideo` 时传入：
+
+```elixir
+[
+  supports_streaming: true,
+  width: display_width,
+  height: display_height,
+  duration: duration
+]
+```
+
+这里还有一个重要取舍：metadata 处理失败不能影响用户拿到视频。
+
+所以实现里做了降级：
+
+- `ffmpeg` 成功，`ffprobe` 失败：仍然发送 faststart 后的视频，只是不带尺寸元数据。
+- `ffmpeg` 失败：回退原文件发送，并再尝试直接探测原文件元数据。
+- `ffmpeg` 和 `ffprobe` 都失败：按原逻辑发送原文件。
+
+这个策略比“失败就报错”更适合 bot。用户发链接是为了保存和转发媒体，不是为了调试我们的媒体处理链路。
+
+## 为什么这次 issue 很有价值
+
+它提醒我们：Bot API 不是 Telegram 客户端。
+
+客户端上传视频时，用户看不到背后的预处理；bot 上传时，很多事情都要我们显式处理。尤其是媒体文件，能播放不代表适合上传，适合上传不代表接收端一定能推断出正确展示方式。
+
+这次也让 save_it 的视频发送链路从“把文件丢给 Telegram”变成了更可靠的媒体处理流程：
+
+1. 下载视频。
+2. 尝试整理 MP4 结构，让它更适合流式播放。
+3. 读取展示尺寸和时长。
+4. 把展示信息显式传给 Telegram。
+5. 所有处理失败都可降级，不阻断发送。
+
+这个变化不大，但边界更清楚了：API 限制归 API 限制，metadata 问题归 metadata 问题，用户体验问题尽量在上传前解决。
+
+## 可以复用的经验
+
+如果你也在用 Telegram Bot API 发送视频，可以记住这几条：
+
+- 普通 Bot API 的视频上传限制要按 50 MB 设计；超过这个边界，考虑 Local Bot API Server、外部存储或发送链接。
+- `supports_streaming` 值得传，但它不是自动播放保证。
+- MP4 上传前尽量做 faststart。
+- 对带旋转 metadata 的视频，不要只相信编码宽高，要计算展示宽高。
+- 能从文件里读出的关键媒体信息，尽量显式传给 API。
+- 媒体预处理失败时，优先降级，而不是让用户请求失败。
+
+这个 bug 的修复最终不是某个神秘参数，而是把“文件可以播放”和“文件适合被 bot 上传并正确展示”这两件事拆开处理。
+
+很多有价值的工程问题都是这样：表面是一个小异常，底下是一层被我们默认忽略的系统边界。
+
+## References
+
+- [Telegram Bot API: sendVideo](https://core.telegram.org/bots/api#sendvideo)
+- [Telegram Bot API: Using a Local Bot API Server](https://core.telegram.org/bots/api#using-a-local-bot-api-server)

--- a/docs/postmortem/2026-06-13-telegram-video-aspect-ratio.md
+++ b/docs/postmortem/2026-06-13-telegram-video-aspect-ratio.md
@@ -1,0 +1,22 @@
+# Telegram Video Aspect Ratio and Streaming Preparation
+
+## What happened
+
+Some videos sent through the bot displayed with an incorrect aspect ratio in Telegram, even though the original file displayed correctly when manually downloaded and uploaded. Larger videos also did not always start loading as streamable videos in Telegram clients.
+
+## Root cause
+
+The bot uploaded downloaded MP4 files with `supports_streaming: true`, but it did not pass video dimensions or duration to Telegram. Videos with rotation/display metadata can be misinterpreted when Telegram derives dimensions from the raw upload. The bot also sent MP4 files as downloaded, so files whose `moov` atom was not optimized for streaming were less likely to behave like streamable Telegram videos.
+
+## Fix applied
+
+MP4 uploads now go through a video upload preparation step before `sendVideo`:
+
+- Use `ffmpeg -c copy -movflags +faststart` to prepare MP4 files for streaming when possible.
+- Use `ffprobe` to read width, height, duration, and rotation metadata.
+- Pass `width`, `height`, `duration`, and `supports_streaming` to Telegram `sendVideo`.
+- Fall back to the original upload when `ffmpeg` or `ffprobe` fails, so downloads are not blocked by metadata extraction.
+
+## What we learned
+
+`supports_streaming` is necessary but not enough. Telegram clients also benefit from MP4 files being faststart-ready, and bots should provide explicit display dimensions for videos whose container metadata may otherwise be interpreted differently from the original player or a manual Telegram client upload.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -10,6 +10,7 @@ defmodule SaveIt.Bot do
   alias SaveIt.FileHelper
   alias SaveIt.GoogleDrive
   alias SaveIt.GoogleOAuth2DeviceFlow
+  alias SaveIt.VideoUpload
 
   alias SaveIt.PhotoService
 
@@ -992,9 +993,12 @@ defmodule SaveIt.Bot do
         |> safe_index_photo()
 
       ".mp4" ->
-        case ExGram.send_video(chat_id, content,
-               supports_streaming: true,
-               caption: caption
+        {prepared_content, video_metadata} = VideoUpload.prepare(content)
+
+        case ExGram.send_video(
+               chat_id,
+               prepared_content,
+               video_send_opts(caption, video_metadata)
              ) do
           {:ok, msg} = response ->
             index_sent_video_preview(chat_id, msg,
@@ -1014,6 +1018,20 @@ defmodule SaveIt.Bot do
 
       _ ->
         ExGram.send_document(chat_id, content, caption: caption)
+    end
+  end
+
+  defp video_send_opts(caption, video_metadata) do
+    [supports_streaming: true, caption: caption]
+    |> maybe_put_video_metadata(:width, video_metadata)
+    |> maybe_put_video_metadata(:height, video_metadata)
+    |> maybe_put_video_metadata(:duration, video_metadata)
+  end
+
+  defp maybe_put_video_metadata(opts, key, metadata) when is_map(metadata) do
+    case Map.get(metadata, key) do
+      value when is_integer(value) and value > 0 -> Keyword.put(opts, key, value)
+      _ -> opts
     end
   end
 

--- a/lib/save_it/video_metadata.ex
+++ b/lib/save_it/video_metadata.ex
@@ -1,0 +1,136 @@
+defmodule SaveIt.VideoMetadata do
+  @moduledoc false
+
+  require Logger
+
+  def probe_file_content(file_content, file_name) when is_binary(file_content) do
+    with_temp_file(file_name, file_content, &probe_file/1)
+  end
+
+  def probe_file(file_path) when is_binary(file_path) do
+    args = [
+      "-v",
+      "error",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=width,height,duration:stream_tags=rotate:side_data=rotation:format=duration",
+      "-of",
+      "json",
+      file_path
+    ]
+
+    case System.cmd("ffprobe", args, stderr_to_stdout: true) do
+      {json, 0} ->
+        decode_metadata(json)
+
+      {output, exit_code} ->
+        {:error, {:ffprobe_failed, exit_code, output}}
+    end
+  rescue
+    error in ErlangError ->
+      {:error, {:ffprobe_unavailable, error}}
+  end
+
+  defp decode_metadata(json) do
+    with {:ok, decoded} <- Jason.decode(json),
+         %{} = stream <- decoded |> Map.get("streams", []) |> List.first(),
+         {:ok, width} <- positive_integer(stream["width"]),
+         {:ok, height} <- positive_integer(stream["height"]) do
+      duration =
+        stream["duration"] ||
+          get_in(decoded, ["format", "duration"])
+
+      {display_width, display_height} =
+        display_dimensions(width, height, rotation(stream))
+
+      metadata =
+        %{
+          width: display_width,
+          height: display_height,
+          duration: duration_integer(duration)
+        }
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+        |> Map.new()
+
+      {:ok, metadata}
+    else
+      {:error, reason} ->
+        {:error, reason}
+
+      error ->
+        {:error, {:invalid_ffprobe_output, error}}
+    end
+  end
+
+  defp display_dimensions(width, height, rotation) when rotation in [90, 270, -90, -270],
+    do: {height, width}
+
+  defp display_dimensions(width, height, _rotation), do: {width, height}
+
+  defp rotation(stream) do
+    [
+      get_in(stream, ["tags", "rotate"]),
+      side_data_rotation(stream["side_data_list"])
+    ]
+    |> Enum.find_value(&integer_value/1)
+    |> Kernel.||(0)
+  end
+
+  defp side_data_rotation(side_data_list) when is_list(side_data_list) do
+    Enum.find_value(side_data_list, &Map.get(&1, "rotation"))
+  end
+
+  defp side_data_rotation(_side_data_list), do: nil
+
+  defp duration_integer(nil), do: nil
+
+  defp duration_integer(value) when is_integer(value) and value > 0, do: value
+
+  defp duration_integer(value) do
+    case Float.parse(to_string(value)) do
+      {seconds, _rest} when seconds > 0 -> round(seconds)
+      _ -> nil
+    end
+  end
+
+  defp positive_integer(value) when is_integer(value) and value > 0, do: {:ok, value}
+
+  defp positive_integer(value) do
+    case Integer.parse(to_string(value)) do
+      {integer, _rest} when integer > 0 -> {:ok, integer}
+      _ -> {:error, :missing_video_dimensions}
+    end
+  end
+
+  defp integer_value(nil), do: nil
+  defp integer_value(value) when is_integer(value), do: value
+
+  defp integer_value(value) do
+    case Integer.parse(to_string(value)) do
+      {integer, _rest} -> integer
+      :error -> nil
+    end
+  end
+
+  defp with_temp_file(file_name, file_content, fun) do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "save-it-video-metadata-#{System.unique_integer([:positive])}")
+
+    tmp_path = Path.join(tmp_dir, file_name)
+
+    try do
+      File.mkdir_p!(tmp_dir)
+      File.write!(tmp_path, file_content)
+      fun.(tmp_path)
+    after
+      case File.rm_rf(tmp_dir) do
+        {:ok, _files} ->
+          :ok
+
+        {:error, reason, _file} ->
+          Logger.warning("Failed to remove temp video metadata file: #{inspect(reason)}")
+      end
+    end
+  end
+end

--- a/lib/save_it/video_upload.ex
+++ b/lib/save_it/video_upload.ex
@@ -1,0 +1,116 @@
+defmodule SaveIt.VideoUpload do
+  @moduledoc false
+
+  require Logger
+
+  alias SaveIt.VideoMetadata
+
+  def prepare({:file_content, file_content, file_name})
+      when is_binary(file_content) and is_binary(file_name) do
+    case preparer().prepare_file_content(file_content, file_name) do
+      {:ok, prepared_content, metadata} ->
+        {{:file_content, prepared_content, file_name}, metadata}
+
+      {:error, reason} ->
+        Logger.warning("Skipping video faststart preparation: #{inspect(reason)}")
+        {{:file_content, file_content, file_name}, probe_file_content(file_content, file_name)}
+    end
+  end
+
+  def prepare({:file, file_path}) when is_binary(file_path) do
+    file_name = Path.basename(file_path)
+
+    case File.read(file_path) do
+      {:ok, file_content} ->
+        prepare({:file_content, file_content, file_name})
+
+      {:error, reason} ->
+        Logger.warning("Skipping video metadata probing: #{inspect(reason)}")
+        {{:file, file_path}, %{}}
+    end
+  end
+
+  defp probe_file_content(file_content, file_name) do
+    case metadata_probe().probe_file_content(file_content, file_name) do
+      {:ok, metadata} ->
+        metadata
+
+      {:error, reason} ->
+        Logger.warning("Skipping video metadata probing: #{inspect(reason)}")
+        %{}
+    end
+  end
+
+  defp preparer do
+    Application.get_env(:save_it, :video_upload_preparer, __MODULE__.FFmpegFaststart)
+  end
+
+  defp metadata_probe do
+    Application.get_env(:save_it, :video_metadata_probe, VideoMetadata)
+  end
+
+  defmodule FFmpegFaststart do
+    @moduledoc false
+
+    def prepare_file_content(file_content, file_name)
+        when is_binary(file_content) and is_binary(file_name) do
+      with_temp_files(file_name, file_content, fn input_path, output_path ->
+        args = [
+          "-y",
+          "-i",
+          input_path,
+          "-map",
+          "0",
+          "-c",
+          "copy",
+          "-movflags",
+          "+faststart",
+          "-loglevel",
+          "warning",
+          output_path
+        ]
+
+        with {_output, 0} <- System.cmd("ffmpeg", args, stderr_to_stdout: true),
+             {:ok, prepared_content} <- File.read(output_path) do
+          {:ok, prepared_content, probe_metadata(prepared_content, file_name)}
+        else
+          {output, exit_code} when is_integer(exit_code) ->
+            {:error, {:ffmpeg_failed, exit_code, output}}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+      end)
+    rescue
+      error in ErlangError ->
+        {:error, {:ffmpeg_unavailable, error}}
+    end
+
+    defp metadata_probe do
+      Application.get_env(:save_it, :video_metadata_probe, VideoMetadata)
+    end
+
+    defp probe_metadata(file_content, file_name) do
+      case metadata_probe().probe_file_content(file_content, file_name) do
+        {:ok, metadata} -> metadata
+        {:error, _reason} -> %{}
+      end
+    end
+
+    defp with_temp_files(file_name, file_content, fun) do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "save-it-video-upload-#{System.unique_integer([:positive])}")
+
+      input_path = Path.join(tmp_dir, "input#{Path.extname(file_name)}")
+      output_path = Path.join(tmp_dir, file_name)
+
+      try do
+        File.mkdir_p!(tmp_dir)
+        File.write!(input_path, file_content)
+        fun.(input_path, output_path)
+      after
+        File.rm_rf(tmp_dir)
+      end
+    end
+  end
+end

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -287,6 +287,8 @@ defmodule SaveIt.BotTest do
       adapter: &__MODULE__.TelegramDownloadAdapter.request/1
     )
 
+    Application.put_env(:save_it, :video_metadata_probe, __MODULE__.VideoMetadataProbe)
+
     message = %{
       chat: %{id: 12_345, username: "save_it_test_chat"},
       date: 1_717_170_000,
@@ -305,6 +307,9 @@ defmodule SaveIt.BotTest do
     assert multipart_part(parts, "chat_id") == "12345"
     assert multipart_part(parts, "caption") == "created at 2024-06-01"
     assert multipart_part(parts, "supports_streaming") == "true"
+    assert multipart_part(parts, "width") == "1080"
+    assert multipart_part(parts, "height") == "1920"
+    assert multipart_part(parts, "duration") == "12"
 
     assert_receive {:telegram_download_request, telegram_env}
 
@@ -1244,6 +1249,14 @@ defmodule SaveIt.BotTest do
          file_content: SaveIt.BotTest.test_mp4()
        }}
     end
+  end
+
+  defmodule VideoMetadataProbe do
+    def probe_file_content(_file_content, file_name) when is_binary(file_name) do
+      {:ok, %{width: 1080, height: 1920, duration: 12}}
+    end
+
+    def probe_file(_file_path), do: {:error, :unexpected_probe_file}
   end
 
   defmodule TelegramDirectMediaAdapter do


### PR DESCRIPTION
## Summary

- prepare downloaded MP4 uploads with `ffmpeg -movflags +faststart` when possible
- probe MP4 width, height, duration, and rotation with `ffprobe`
- pass video dimensions, duration, and `supports_streaming` to Telegram `sendVideo`
- document the incident in the postmortem and changelog
- add Chinese and English blog posts explaining the issue and the reusable engineering lessons

## Root cause

Downloaded MP4 files were sent with `supports_streaming: true`, but the bot did not pass explicit video dimensions or duration to Telegram. Videos with rotation/display metadata could be interpreted differently by Telegram than by the original player or a manual Telegram client upload. Some MP4 files also were not faststart-ready, making automatic streaming/loading less reliable.

## Docs

- `docs/blog/zh/2026-06-13-telegram-video-metadata.md`
- `docs/blog/en/2026-06-13-telegram-video-metadata.md`
- `docs/postmortem/2026-06-13-telegram-video-aspect-ratio.md`

## Validation

- `mix test` - 32 tests, 0 failures
- `git diff --check` - no whitespace errors for the blog update
