### PR TITLE
chore: rename mix quality alias to checks

### DIFF
--- a/.agents/skills/save-it-development/SKILL.md
+++ b/.agents/skills/save-it-development/SKILL.md
@@ -60,10 +60,10 @@ mix test
 mix format
 mix credo --strict
 mix dialyzer
-mix quality
+mix checks
 ```
 
-`mix quality` is the common check-only suite and must not rewrite files.
+`mix checks` is the common check-only suite and must not rewrite files.
 
 ## Typesense Migrations
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule SaveIt.MixProject do
   def cli do
     [
       preferred_envs: [
-        quality: :dev
+        checks: :dev
       ]
     ]
   end
@@ -46,8 +46,8 @@ defmodule SaveIt.MixProject do
 
   defp aliases do
     [
-      quality: [
-        "format",
+      checks: [
+        "format --check-formatted",
         "compile --warnings-as-errors",
         "credo --strict",
         "dialyzer"


### PR DESCRIPTION
## Summary

- Rename the local Mix alias from `mix quality` to `mix checks`.
- Update the save-it development skill documentation to use `mix checks`.
- Make the checks alias use `mix format --check-formatted` so it remains check-only and does not rewrite files.

## Validation

- `mix help checks` passes and shows the new alias.
- `mix help quality` fails, confirming the old alias is removed.
- `mix format --check-formatted` passes.
- `mix checks` was attempted but is currently blocked by a third-party dependency compile error in `ex_gram` (`updates/webhook.ex` raises `MatchError {:error, :enoent}`).
