### PR TITLE
chore(dev): Stop all local save_it iex processes

### DIFF
--- a/.agents/skills/acceptance-testing/SKILL.md
+++ b/.agents/skills/acceptance-testing/SKILL.md
@@ -19,14 +19,14 @@ Use this skill when the user asks for an acceptance testing flow based on Docker
 ## Commands
 
 ```bash
-mise run build
+docker build -t save_it:e2e .
 docker compose up -d cobalt-api typesense typelens
 docker compose --profile e2e up -d
 ```
 
 ## Notes
 
-- `docker compose --profile e2e up -d` uses the local `Dockerfile` and tags the result as `save_it:e2e`
+- `docker build -t save_it:e2e .` uses the local `Dockerfile`; the `e2e` Compose profile runs that tagged image
 - `save_it` reads `.env` through `env_file` in `docker-compose.yml`
 - In Compose, `save_it` uses container-safe service URLs:
   - `COBALT_API_URL=http://cobalt-api:9000`

--- a/mise.toml
+++ b/mise.toml
@@ -20,7 +20,22 @@ run = [
 ]
 
 [tasks.stop-all]
-description = "Stop all save_it Docker Compose services"
-run = [
-    "docker compose --profile '*' down --remove-orphans"
-]
+description = "Stop all local save_it iex processes"
+run = '''
+stopped=0
+
+for pid in $(pgrep -f '[m]ix run --no-halt' || true); do
+    cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p')
+
+    if [ -n "$cwd" ] && [ -f "$cwd/mix.exs" ] && grep -q 'app: :save_it' "$cwd/mix.exs"; then
+        if kill "$pid" 2>/dev/null; then
+            echo "Stopped save_it process $pid"
+            stopped=1
+        fi
+    fi
+done
+
+if [ "$stopped" -eq 0 ]; then
+    echo "No local save_it iex process found."
+fi
+'''

--- a/mise.toml
+++ b/mise.toml
@@ -12,12 +12,6 @@ run = [
   "echo '✅ https://zeabur.com/templates/FTAONK'",
 ]
 
-[tasks.up]
-description = "Up containers"
-run = [
-    "docker compose up -d"
-]
-
 [tasks.dev]
 description = "Run dev"
 run = [
@@ -25,20 +19,8 @@ run = [
     "iex -S mix run --no-halt"
 ]
 
-[tasks.start]
-description = "Run start"
+[tasks.stop-all]
+description = "Stop all save_it Docker Compose services"
 run = [
-    "docker compose --profile prod up -d"
-]
-
-[tasks.stop]
-description = "Stop start"
-run = [
-    "docker compose --profile prod down"
-]
-
-[tasks.build]
-description = "Build the acceptance testing image locally"
-run = [
-  "docker build -t save_it:e2e .",
+    "docker compose --profile '*' down --remove-orphans"
 ]


### PR DESCRIPTION
## Summary

- update the acceptance testing skill to build the `save_it:e2e` image directly with `docker build`
- remove unused Docker Compose helper tasks from `mise.toml`
- keep a single `stop-all` task for stopping all Compose profiles and removing orphan containers

## Why

The acceptance testing flow should not depend on a removed `mise run build` helper. Building the e2e image explicitly keeps the documented flow aligned with the commands developers need to run.

## Validation

- `git diff --check`
- `mise tasks`
