### PR TITLE
fix(ci): preserve prerelease stag image tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,6 +31,7 @@ jobs:
           images: ghcr.io/thaddeusjiang/save_it
           tags: |
             type=raw,value=latest,enable=${{ !inputs.is_prerelease }}
+            type=raw,value=stag,enable=${{ inputs.is_prerelease }}
             type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
       - name: Set up QEMU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ before the CalVer migration retain their original version labels.
 ### Fixed
 
 - Fix Zeabur Cobalt cookie setup to use a file config at `/cookies.json` instead of mounting a volume as a file.
+- Keep GHCR prerelease images reachable through the `stag` tag after stable `latest` images are published.
 
 ## [2026.6.14] - 2026-06-14
 

--- a/docs/postmortem/2026-06-14-ghcr-stag-tag-dropped-on-latest-release.md
+++ b/docs/postmortem/2026-06-14-ghcr-stag-tag-dropped-on-latest-release.md
@@ -1,0 +1,17 @@
+# GHCR Stag Tag Dropped on Latest Release
+
+## What happened
+
+After a stable `latest` image was published to GHCR, the expected `ghcr.io/thaddeusjiang/save_it:stag` image tag was no longer available. A direct registry check returned `not found` for `stag`, while `latest` still resolved to a multi-platform manifest.
+
+## Root cause
+
+The reusable Docker publish workflow did not publish a floating `stag` tag for prereleases. Prerelease builds only pushed the immutable release version tag, and stable releases pushed `latest` plus the same version tag. When the version tag moved to the stable image, no separate prerelease tag remained to keep the staging image reachable.
+
+## Fix applied
+
+The Docker metadata step now publishes `stag` when `inputs.is_prerelease` is true. Stable releases continue to publish `latest` and the requested version tag. A workflow regression test now checks that prerelease builds include `stag` and stable builds keep the existing `latest` behavior.
+
+## What we learned
+
+Prerelease images need an environment-style floating tag in addition to the release version tag. Otherwise, promoting or republishing the same version as stable can leave staging without a durable image reference.

--- a/test/github_workflow_test.exs
+++ b/test/github_workflow_test.exs
@@ -1,0 +1,17 @@
+defmodule SaveIt.GitHubWorkflowTest do
+  use ExUnit.Case, async: true
+
+  @docker_publish_workflow ".github/workflows/docker-publish.yml"
+
+  test "publishes a floating stag tag for prerelease images" do
+    workflow = File.read!(@docker_publish_workflow)
+
+    assert workflow =~ "type=raw,value=stag,enable=${{ inputs.is_prerelease }}"
+  end
+
+  test "publishes latest only for stable release images" do
+    workflow = File.read!(@docker_publish_workflow)
+
+    assert workflow =~ "type=raw,value=latest,enable=${{ !inputs.is_prerelease }}"
+  end
+end


### PR DESCRIPTION
## Summary

- publish a floating `stag` GHCR tag for prerelease Docker images
- add a workflow regression test for prerelease `stag` and stable `latest` metadata
- document the incident in the changelog and postmortem

## Root Cause

The Docker publish workflow only pushed prerelease images with their immutable version tag. Stable releases pushed the same version tag plus `latest`, leaving no independent prerelease reference for staging.

## Validation

- `mix test test/github_workflow_test.exs`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path); puts "ok #{path}" }'`
- `git diff --check HEAD~1..HEAD`
