### PR TITLE
fix: store URL media metadata in Typesense

### DIFF
--- a/.agents/skills/save-it-development/SKILL.md
+++ b/.agents/skills/save-it-development/SKILL.md
@@ -11,6 +11,8 @@ Use this skill for routine development work in the `save_it` repository.
 
 ## Setup
 
+If the current checkout is a git worktree and this project has not completed setup yet, run `worktree init` skill first, then run the full setup below.
+
 Run from the repository root:
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,20 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Added
+
+- Store public link preview thumbnail URLs in Typesense for URL media saves and webpage preview fallbacks.
+
+### Changed
+
+- Use YouTube Open Graph titles as captions for URL-only saves, keep X captions based on Open Graph descriptions with title fallback, and log fetched link preview metadata.
+
 ### Fixed
 
 - Fix Zeabur Cobalt cookie setup to use a file config at `/cookies.json` instead of mounting a volume as a file.
 - Keep GHCR prerelease images reachable through the `stag` tag after stable `latest` images are published.
+- Send URL-downloaded media back to the source Telegram topic, build private supergroup topic source message URLs with the message thread id, and stop indexing the unused `source_message_id` field.
+- Store resolved media download URLs in Typesense for successful URL photo, video, HLS, and multi-image saves.
 
 ## [2026.6.14] - 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ before the CalVer migration retain their original version labels.
 
 - Fix Zeabur Cobalt cookie setup to use a file config at `/cookies.json` instead of mounting a volume as a file.
 - Keep GHCR prerelease images reachable through the `stag` tag after stable `latest` images are published.
+- Log link preview metadata fetch failures so missing URL captions and thumbnail URLs can be diagnosed from runtime logs.
 - Send URL-downloaded media back to the source Telegram topic, build private supergroup topic source message URLs with the message thread id, and stop indexing the unused `source_message_id` field.
 - Stop storing invalid Telegram `source_message_url` values for private DM saves, where Telegram does not provide a direct message URL.
 - Store resolved media download URLs in Typesense for successful URL photo, video, HLS, and multi-image saves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ before the CalVer migration retain their original version labels.
 - Fix Zeabur Cobalt cookie setup to use a file config at `/cookies.json` instead of mounting a volume as a file.
 - Keep GHCR prerelease images reachable through the `stag` tag after stable `latest` images are published.
 - Send URL-downloaded media back to the source Telegram topic, build private supergroup topic source message URLs with the message thread id, and stop indexing the unused `source_message_id` field.
+- Stop storing invalid Telegram `source_message_url` values for private DM saves, where Telegram does not provide a direct message URL.
 - Store resolved media download URLs in Typesense for successful URL photo, video, HLS, and multi-image saves.
 
 ## [2026.6.14] - 2026-06-14

--- a/docs/postmortem/2026-06-14-download-url-indexing.md
+++ b/docs/postmortem/2026-06-14-download-url-indexing.md
@@ -1,0 +1,19 @@
+# Download URL Missing from Indexed URL Media
+
+## What happened
+
+URL media downloads saved to Telegram and Typesense successfully, but the indexed Typesense document did not include `download_url`. Operators could see the original page URL and Telegram source message URL, but not the resolved media URL returned by Cobalt or the HLS resolver.
+
+## Root cause
+
+The Typesense schema and `PhotoService` already supported `download_url`, and `WebDownloader` carried the resolved URL on `%DownloadedFile{}`. The bot send/index pipeline dropped that value: it passed only the original source URL through `bot_send_*` helpers, and video preview indexing received only `source_url`.
+
+Multi-image downloads had the same issue because file tuples contained only the original source URL even though each downloaded file had its own resolved media URL.
+
+## Fix applied
+
+The download context now includes the resolved media URL when available. Bot send helpers propagate `download_url` into image, video, HLS, and multi-image Typesense documents. Multi-image indexing stores each item's own media URL. Thumbnail fallback saves still avoid writing preview-image URLs as media `download_url` values.
+
+## What we learned
+
+Resolved media URLs cross several boundaries: resolver, downloader, Telegram upload, thumbnail indexing, and Typesense persistence. Fields that are already present in schema still need explicit propagation through every send/index branch, especially when video indexing happens after Telegram returns the sent message.

--- a/docs/postmortem/2026-06-14-source-message-url.md
+++ b/docs/postmortem/2026-06-14-source-message-url.md
@@ -1,0 +1,21 @@
+# Source Message URL for Telegram Topics
+
+## What happened
+
+Saved media could include a `source_message_url`, but opening the link did not always jump to the expected Telegram message. The stored `source_message_id` also appeared to be unused by the bot after indexing.
+
+## Root cause
+
+The source message URL builder only used the chat id and message id. For private supergroup topic messages, Telegram deep links need the topic `message_thread_id` between the internal chat id and the message id. The indexing path passed only the numeric message id into the source field helper, so the helper had no access to the thread id even when Telegram provided it on the message.
+
+For URL downloads, the bot also sent the downloaded media without forwarding the original message thread id, so saved media could leave the source topic instead of staying next to the user request.
+
+`source_message_id` was stored in Typesense, but the details command and bot behavior only read `source_message_url`.
+
+## Fix applied
+
+Source field generation now receives the Telegram message object, extracts `message_thread_id` when present, and builds private supergroup topic URLs as `https://t.me/c/<chat>/<thread>/<message>`. URL-downloaded media is sent with the original message thread id so the saved Telegram message remains in the source topic. The bot no longer writes `source_message_id` into new Typesense documents, and a Typesense migration drops the unused field from the `photos` schema while preserving rollback support.
+
+## What we learned
+
+Telegram message links are not described by `chat_id` and `message_id` alone once forum topics are involved. URL construction and Telegram sends should keep the original message thread context available until the final saved message is created, and stored search schema fields should be trimmed when no product behavior reads them.

--- a/docs/postmortem/2026-06-14-thumbnail-url-indexing.md
+++ b/docs/postmortem/2026-06-14-thumbnail-url-indexing.md
@@ -1,0 +1,19 @@
+# Thumbnail URL Missing from Indexed URL Media
+
+## What happened
+
+URL media saves could include a searchable image thumbnail in Typesense, but the document did not keep the public thumbnail URL. Operators could inspect the original page URL and the resolved media download URL, yet could not see which Open Graph image URL was used as the preview source.
+
+## Root cause
+
+The bot already fetched link preview metadata for captions and webpage preview fallback images, but only the image bytes were passed into Typesense. The `og:image` URL stayed inside the link preview helper and was not propagated through the bot send/index options. Typesense also lacked a `thumbnail_url` field, so there was no schema target for the value.
+
+Telegram-provided thumbnails need special handling because their downloadable file URLs include the bot token. Those URLs are useful for fetching bytes internally, but should not be stored as public document metadata.
+
+## Fix applied
+
+Typesense now has an optional `thumbnail_url` field. URL media saves reuse link preview metadata to pass public preview image URLs through the bot send/index pipeline for photos, videos, HLS videos, and webpage preview fallback saves. Telegram-only thumbnail fallbacks still avoid writing tokenized Telegram file URLs.
+
+## What we learned
+
+Thumbnail bytes and thumbnail source URLs are separate pieces of state. A document can have a searchable thumbnail image without having a safe public thumbnail URL, so the indexing pipeline needs to carry the URL explicitly and only persist URLs that are safe to expose.

--- a/docs/postmortem/2026-06-14-x-link-preview-caption.md
+++ b/docs/postmortem/2026-06-14-x-link-preview-caption.md
@@ -1,0 +1,17 @@
+# X Link Preview Caption Fallback
+
+## What happened
+
+An X link could download a video successfully, but Telegram did not show a caption derived from the page preview. The runtime logs only showed the Cobalt failure/fallback attempts and file writes, so it was unclear whether the bot had fetched Open Graph title, description, or image metadata.
+
+## Root cause
+
+The URL caption path fetched only the single field selected for that service. X links used `og:description`, and if the preview page did not provide a description while still providing `og:title`, the caption path returned an empty string. Because link preview extraction did not log the fetched Open Graph fields, the missing caption was hard to diagnose from local logs.
+
+## Fix applied
+
+Link preview fetching now extracts title, description, and image URL together and logs a concise metadata summary without dumping raw HTML. YouTube URL-only saves still use `og:title`. X and Twitter URL-only saves use `og:description` first, then fall back to `og:title` when no description is available. The bot also logs which Open Graph field was selected as the caption source.
+
+## What we learned
+
+Caption selection and preview image fallback both depend on the same webpage metadata, so logging only download progress is not enough. Link preview code should expose the metadata boundary clearly: what URL was fetched, which Open Graph fields were present, and which field became the user-visible caption.

--- a/docs/postmortem/2026-06-15-dm-source-message-url.md
+++ b/docs/postmortem/2026-06-15-dm-source-message-url.md
@@ -1,0 +1,21 @@
+# Private DM Source Message URLs
+
+## What happened
+
+Media saved from a private DM with the bot could include a `source_message_url` like `https://t.me/<username>/<message_id>`. That URL shape is valid for public chats with message links, but it does not jump to a specific message inside a private one-on-one bot DM.
+
+## Root cause
+
+The source message URL builder treated any chat with a `username` as a public Telegram peer and generated a public `t.me/<username>/<message_id>` message URL. Telegram Bot API private chats can also include a user `username`, so DM saves were misclassified.
+
+Telegram's official deep links documentation describes message links as links to specific messages in public or private groups and channels. It documents user links for opening a chat/profile, but not a supported direct URL to jump to a specific message in a private DM.
+
+Reference: https://core.telegram.org/api/links#message-links
+
+## Fix applied
+
+Source message URL generation now checks `chat.type`. When Telegram marks the source chat as `private`, the bot does not write `source_message_url` into Typesense. Public username chats and private supergroup/channel `t.me/c/...` links keep their existing behavior.
+
+## What we learned
+
+Telegram usernames are not enough to decide whether a message link can be built. The chat type must participate in URL generation, and private DM messages should be recorded as having no direct jump URL instead of storing a misleading public-message URL.

--- a/docs/postmortem/2026-06-15-link-preview-failure-logs.md
+++ b/docs/postmortem/2026-06-15-link-preview-failure-logs.md
@@ -1,0 +1,17 @@
+# Link Preview Failure Logs Missing
+
+## What happened
+
+An X URL could be resolved and downloaded through Cobalt, and Typesense stored the media `download_url`, but the indexed document still had an empty caption and no `thumbnail_url`. The runtime logs only showed download and file write progress, not whether the bot fetched Open Graph title, description, or image metadata.
+
+## Root cause
+
+The bot relies on `SmallSdk.LinkPreview.get_metadata/1` for URL captions and public thumbnail URLs. For the affected X URL, the same helper returned `{:error, {:preview_page_status, 404}}` when requesting the preview page directly. That error path was silently converted to `nil` by the caller, and `LinkPreview` only logged successful 2xx metadata fetches. As a result, operators could not distinguish "metadata was empty" from "metadata fetch failed".
+
+## Fix applied
+
+`SmallSdk.LinkPreview.get_metadata/1` now logs a concise warning when the preview request returns a non-2xx status or fails at the HTTP layer. The log includes the sanitized preview page URL and the failure reason, while successful metadata logs continue to include title, description, and image URL summaries.
+
+## What we learned
+
+Cobalt cookies and Cobalt download success do not guarantee that the bot's separate Open Graph request can read the same X page. Link preview fetch failures need first-class logs because they directly explain missing captions and missing public thumbnail URLs.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -323,7 +323,7 @@ defmodule SaveIt.Bot do
       media_type: "photo",
       belongs_to_id: chat.id
     }
-    |> Map.merge(source_message_fields(chat, message_id(message)))
+    |> Map.merge(source_message_fields(chat, message))
     |> safe_typesense_create_photo()
     |> answer_similar_for_uploaded_media(chat.id, caption)
   end
@@ -332,15 +332,15 @@ defmodule SaveIt.Bot do
     typesense_photo =
       video
       |> video_thumbnail()
-      |> create_video_thumbnail_index(chat, message_id(message), caption, video.file_id)
+      |> create_video_thumbnail_index(chat, message, caption, video.file_id)
 
     store_uploaded_video_file(chat.id, video)
     answer_similar_for_uploaded_media(typesense_photo, chat.id, caption)
   end
 
-  defp create_video_thumbnail_index(nil, _chat, _message_id, _caption, _file_id), do: nil
+  defp create_video_thumbnail_index(nil, _chat, _message, _caption, _file_id), do: nil
 
-  defp create_video_thumbnail_index(thumbnail, chat, message_id, caption, file_id) do
+  defp create_video_thumbnail_index(thumbnail, chat, message, caption, file_id) do
     thumbnail_file = ExGram.get_file!(thumbnail.file_id)
     thumbnail_content = Telegram.download_file_content!(thumbnail_file.file_path)
 
@@ -351,7 +351,7 @@ defmodule SaveIt.Bot do
       media_type: "video",
       belongs_to_id: chat.id
     }
-    |> Map.merge(source_message_fields(chat, message_id))
+    |> Map.merge(source_message_fields(chat, message))
     |> safe_typesense_create_photo()
   end
 
@@ -520,7 +520,7 @@ defmodule SaveIt.Bot do
 
     case resolve_download_url(url) do
       {:ok, m3u8_url, :hls} ->
-        handle_hls_download(%{context | cache_url: url}, m3u8_url)
+        handle_hls_download(%{context | cache_url: url, download_url: m3u8_url}, m3u8_url)
 
       {:ok, purge_url, download_urls} ->
         handle_multi_file_download(%{context | purge_url: purge_url}, download_urls)
@@ -551,11 +551,7 @@ defmodule SaveIt.Bot do
       {:ok, %DownloadedFile{} = file} ->
         update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
 
-        bot_send_downloaded_file(context.chat_id, file,
-          source_url: context.original_url,
-          source_chat: context.chat,
-          caption: download_caption(context)
-        )
+        bot_send_downloaded_file(context.chat_id, file, download_send_opts(context))
 
         finalize_single_download(context, file)
 
@@ -576,11 +572,7 @@ defmodule SaveIt.Bot do
       downloaded_files ->
         update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
 
-        bot_send_filenames(context.chat_id, downloaded_files,
-          source_url: context.original_url,
-          source_chat: context.chat,
-          caption: download_caption(context)
-        )
+        bot_send_filenames(context.chat_id, downloaded_files, download_send_opts(context))
 
         delete_message(context.chat_id, context.progress_message_id)
         :ok
@@ -594,11 +586,7 @@ defmodule SaveIt.Bot do
       {:ok, files} ->
         update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
 
-        bot_send_files(context.chat_id, files,
-          source_url: context.original_url,
-          source_chat: context.chat,
-          caption: download_caption(context)
-        )
+        bot_send_files(context.chat_id, files, download_send_opts(context))
 
         delete_message(context.chat_id, context.progress_message_id)
         FileHelper.write_folder(context.purge_url, files)
@@ -618,10 +606,11 @@ defmodule SaveIt.Bot do
       downloaded_file ->
         update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
 
-        bot_send_file(context.chat_id, downloaded_file, {:file, downloaded_file},
-          source_url: context.original_url,
-          source_chat: context.chat,
-          caption: download_caption(context)
+        bot_send_file(
+          context.chat_id,
+          downloaded_file,
+          {:file, downloaded_file},
+          download_send_opts(context)
         )
 
         delete_message(context.chat_id, context.progress_message_id)
@@ -636,11 +625,7 @@ defmodule SaveIt.Bot do
       {:ok, %DownloadedFile{} = file} ->
         update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
 
-        bot_send_downloaded_file(context.chat_id, file,
-          source_url: context.original_url,
-          source_chat: context.chat,
-          caption: download_caption(context)
-        )
+        bot_send_downloaded_file(context.chat_id, file, download_send_opts(context))
 
         finalize_single_download(context, file)
 
@@ -653,7 +638,7 @@ defmodule SaveIt.Bot do
     case download_fallback_thumbnail(context) do
       {:ok, %DownloadedFile{} = file, source} ->
         log_thumbnail_fallback_success(source)
-        save_thumbnail_fallback(context, file)
+        save_thumbnail_fallback(context, file, source)
 
       {:error, _fallback_reasons} ->
         Logger.warning("No thumbnail fallback available after link download failed")
@@ -687,17 +672,79 @@ defmodule SaveIt.Bot do
     Logger.warning("Saved webpage preview fallback after link download failed")
   end
 
-  defp save_thumbnail_fallback(%DownloadContext{} = context, %DownloadedFile{} = file) do
+  defp save_thumbnail_fallback(%DownloadContext{} = context, %DownloadedFile{} = file, source) do
     update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
 
-    bot_send_downloaded_file(context.chat_id, file,
-      source_url: context.original_url,
-      source_chat: context.chat,
-      caption: download_caption(context)
+    bot_send_downloaded_file(
+      context.chat_id,
+      file,
+      download_send_opts(context, store_thumbnail_url?: source == :webpage_preview)
+      |> Keyword.put(:store_download_url?, false)
     )
 
     finalize_thumbnail_download(context, file)
   end
+
+  defp download_send_opts(%DownloadContext{} = context, opts \\ []) do
+    metadata = download_link_preview_metadata(context, opts)
+
+    [
+      source_url: context.original_url,
+      source_chat: context.chat,
+      caption: download_caption(context, metadata)
+    ]
+    |> put_optional_keyword(:download_url, context.download_url)
+    |> put_optional_keyword(:thumbnail_url, thumbnail_url_from_metadata(metadata, opts))
+    |> put_optional_keyword(:message_thread_id, message_thread_id(context.message))
+  end
+
+  defp download_link_preview_metadata(%DownloadContext{} = context, opts) do
+    context
+    |> download_link_preview_metadata_url(opts)
+    |> fetch_link_preview_metadata()
+  end
+
+  defp download_link_preview_metadata_url(
+         %DownloadContext{message: message, original_url: original_url},
+         opts
+       ) do
+    preview_url = link_preview_url(message)
+    caption_needs_metadata? = user_text_caption(message) == ""
+
+    thumbnail_needs_metadata? =
+      Keyword.get(opts, :store_thumbnail_url?, true) and is_binary(preview_url)
+
+    cond do
+      is_binary(preview_url) and (caption_needs_metadata? or thumbnail_needs_metadata?) ->
+        preview_url
+
+      caption_needs_metadata? ->
+        original_url
+
+      true ->
+        nil
+    end
+  end
+
+  defp fetch_link_preview_metadata(preview_url) when is_binary(preview_url) do
+    case LinkPreview.get_metadata(preview_url) do
+      {:ok, metadata} -> metadata
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp fetch_link_preview_metadata(_preview_url), do: nil
+
+  defp thumbnail_url_from_metadata(metadata, opts) do
+    if Keyword.get(opts, :store_thumbnail_url?, true) do
+      metadata_image_url(metadata)
+    end
+  end
+
+  defp metadata_image_url(%{image_url: image_url}) when is_binary(image_url) and image_url != "",
+    do: image_url
+
+  defp metadata_image_url(_metadata), do: nil
 
   defp download_message_thumbnail(message) do
     with thumbnail when not is_nil(thumbnail) <- message_thumbnail(message),
@@ -782,13 +829,13 @@ defmodule SaveIt.Bot do
     :ok
   end
 
-  defp download_caption(%DownloadContext{message: message, original_url: original_url}) do
+  defp download_caption(%DownloadContext{message: message, original_url: original_url}, metadata) do
     case user_text_caption(message) do
       caption when is_binary(caption) and caption != "" ->
         caption
 
       _ ->
-        link_preview_description(message, original_url)
+        link_preview_caption(message, original_url, metadata)
     end
   end
 
@@ -807,17 +854,104 @@ defmodule SaveIt.Bot do
 
   defp strip_urls_from_text(_text), do: ""
 
-  defp link_preview_description(message, original_url) do
-    (link_preview_url(message) || original_url)
-    |> case do
-      url when is_binary(url) -> LinkPreview.get_description(url)
-      _ -> {:error, :missing_preview_url}
+  defp link_preview_caption(_message, original_url, metadata) when is_map(metadata) do
+    case caption_from_link_preview_metadata(metadata, original_url) do
+      {:ok, caption, source} ->
+        Logger.info("Link preview caption selected: source=#{source}", kind: :link_preview)
+        caption
+
+      {:error, _reason} ->
+        ""
     end
+  end
+
+  defp link_preview_caption(message, original_url, _metadata) do
+    preview_url = link_preview_url(message) || original_url
+
+    preview_url
+    |> fetch_link_preview_caption(original_url)
     |> case do
-      {:ok, description} -> description
+      {:ok, caption} -> caption
       {:error, _reason} -> ""
     end
   end
+
+  defp fetch_link_preview_caption(preview_url, original_url) when is_binary(preview_url) do
+    with {:ok, metadata} <- LinkPreview.get_metadata(preview_url),
+         {:ok, caption, source} <- caption_from_link_preview_metadata(metadata, original_url) do
+      Logger.info("Link preview caption selected: source=#{source}", kind: :link_preview)
+      {:ok, caption}
+    end
+  end
+
+  defp fetch_link_preview_caption(_preview_url, _original_url), do: {:error, :missing_preview_url}
+
+  defp caption_from_link_preview_metadata(metadata, original_url) do
+    cond do
+      youtube_url?(original_url) ->
+        metadata
+        |> Map.get(:title)
+        |> caption_result(:og_title)
+
+      x_url?(original_url) ->
+        metadata
+        |> Map.get(:description)
+        |> caption_result(:og_description)
+        |> fallback_caption_result(Map.get(metadata, :title), :og_title)
+
+      true ->
+        metadata
+        |> Map.get(:description)
+        |> caption_result(:og_description)
+    end
+  end
+
+  defp caption_result(caption, source) when is_binary(caption) and caption != "" do
+    {:ok, caption, source}
+  end
+
+  defp caption_result(_caption, _source), do: {:error, :no_preview_caption}
+
+  defp fallback_caption_result({:ok, _caption, _source} = result, _fallback, _fallback_source),
+    do: result
+
+  defp fallback_caption_result({:error, :no_preview_caption}, fallback, source) do
+    caption_result(fallback, source)
+  end
+
+  defp youtube_url?(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{host: host} when is_binary(host) ->
+        host = String.downcase(host)
+
+        host == "youtube.com" or String.ends_with?(host, ".youtube.com")
+
+      _ ->
+        false
+    end
+  rescue
+    _ -> false
+  end
+
+  defp youtube_url?(_url), do: false
+
+  defp x_url?(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{host: host} when is_binary(host) ->
+        host = String.downcase(host)
+
+        host in ["x.com", "twitter.com"] or
+          String.ends_with?(host, ".x.com") or
+          String.ends_with?(host, ".twitter.com")
+
+      _ ->
+        false
+    end
+  rescue
+    _ -> false
+  end
+
+  defp x_url?(_url), do: false
 
   defp send_message(chat_id, text) do
     ExGram.send_message(chat_id, text)
@@ -839,28 +973,44 @@ defmodule SaveIt.Bot do
     source_url = Keyword.get(opts, :source_url)
     source_chat = Keyword.get(opts, :source_chat)
     caption = Keyword.get(opts, :caption, "")
+    message_thread_id = Keyword.get(opts, :message_thread_id)
+    thumbnail_url = Keyword.get(opts, :thumbnail_url)
 
     if all_images?(files) and length(files) > 1 do
       bot_send_media_group(
         chat_id,
         Enum.map(files, fn %DownloadedFile{} = file ->
-          {file.file_name, {:file_content, file.file_content, file.file_name}, source_url}
+          {file.file_name, {:file_content, file.file_content, file.file_name}, source_url,
+           file.download_url, thumbnail_url}
         end),
         source_chat: source_chat,
-        caption: caption
+        caption: caption,
+        message_thread_id: message_thread_id
       )
     else
       Enum.each(files, fn %DownloadedFile{} = file ->
         bot_send_downloaded_file(chat_id, file,
           source_url: source_url,
           source_chat: source_chat,
-          caption: caption
+          caption: caption,
+          thumbnail_url: thumbnail_url,
+          message_thread_id: message_thread_id
         )
       end)
     end
   end
 
   defp bot_send_downloaded_file(chat_id, %DownloadedFile{} = file, opts) do
+    store_download_url? = Keyword.get(opts, :store_download_url?, true)
+
+    opts =
+      opts
+      |> Keyword.delete(:store_download_url?)
+      |> put_optional_keyword(
+        :download_url,
+        download_url_for_file(file, opts, store_download_url?)
+      )
+
     bot_send_file(
       chat_id,
       file.file_name,
@@ -869,24 +1019,37 @@ defmodule SaveIt.Bot do
     )
   end
 
+  defp download_url_for_file(_file, _opts, false), do: nil
+
+  defp download_url_for_file(%DownloadedFile{} = file, opts, true) do
+    Keyword.get(opts, :download_url) || file.download_url
+  end
+
   defp bot_send_filenames(chat_id, filenames, opts) do
     source_url = Keyword.get(opts, :source_url)
     source_chat = Keyword.get(opts, :source_chat)
     caption = Keyword.get(opts, :caption, "")
+    message_thread_id = Keyword.get(opts, :message_thread_id)
+    thumbnail_url = Keyword.get(opts, :thumbnail_url)
 
     if all_images?(filenames) and length(filenames) > 1 do
       bot_send_media_group(
         chat_id,
-        Enum.map(filenames, fn filename -> {filename, {:file, filename}, source_url} end),
+        Enum.map(filenames, fn filename ->
+          {filename, {:file, filename}, source_url, nil, thumbnail_url}
+        end),
         source_chat: source_chat,
-        caption: caption
+        caption: caption,
+        message_thread_id: message_thread_id
       )
     else
       Enum.each(filenames, fn filename ->
         bot_send_file(chat_id, filename, {:file, filename},
           source_url: source_url,
           source_chat: source_chat,
-          caption: caption
+          caption: caption,
+          thumbnail_url: thumbnail_url,
+          message_thread_id: message_thread_id
         )
       end)
     end
@@ -895,12 +1058,16 @@ defmodule SaveIt.Bot do
   defp bot_send_media_group(chat_id, files, opts) do
     source_chat = Keyword.get(opts, :source_chat) || %{id: chat_id}
     caption = Keyword.get(opts, :caption, "")
+    message_thread_id = Keyword.get(opts, :message_thread_id)
 
-    case Telegram.send_media_group(chat_id, files, caption: caption) do
+    case Telegram.send_media_group(chat_id, files,
+           caption: caption,
+           message_thread_id: message_thread_id
+         ) do
       {:ok, messages} ->
         Enum.zip(files, messages)
         |> Enum.each(fn
-          {{_file_name, content, source_url, _download_url}, msg} ->
+          {{_file_name, content, source_url, download_url, thumbnail_url}, msg} ->
             file_id = get_file_id(msg)
             image_base64 = encode_file_content(content)
 
@@ -911,7 +1078,24 @@ defmodule SaveIt.Bot do
               url: source_url,
               belongs_to_id: chat_id
             }
-            |> Map.merge(source_message_fields(source_chat, message_id(msg)))
+            |> put_optional(:download_url, download_url)
+            |> put_optional(:thumbnail_url, thumbnail_url)
+            |> Map.merge(source_message_fields(source_chat, msg))
+            |> PhotoService.create_photo!()
+
+          {{_file_name, content, source_url, download_url}, msg} ->
+            file_id = get_file_id(msg)
+            image_base64 = encode_file_content(content)
+
+            %{
+              image: image_base64,
+              caption: caption,
+              file_id: file_id,
+              url: source_url,
+              belongs_to_id: chat_id
+            }
+            |> put_optional(:download_url, download_url)
+            |> Map.merge(source_message_fields(source_chat, msg))
             |> PhotoService.create_photo!()
 
           {{_file_name, content, source_url}, msg} ->
@@ -925,7 +1109,7 @@ defmodule SaveIt.Bot do
               url: source_url,
               belongs_to_id: chat_id
             }
-            |> Map.merge(source_message_fields(source_chat, message_id(msg)))
+            |> Map.merge(source_message_fields(source_chat, msg))
             |> PhotoService.create_photo!()
 
           {{_file_name, content}, msg} ->
@@ -938,7 +1122,7 @@ defmodule SaveIt.Bot do
               file_id: file_id,
               belongs_to_id: chat_id
             }
-            |> Map.merge(source_message_fields(source_chat, message_id(msg)))
+            |> Map.merge(source_message_fields(source_chat, msg))
             |> PhotoService.create_photo!()
         end)
 
@@ -946,22 +1130,39 @@ defmodule SaveIt.Bot do
         Logger.error("Failed to send media group")
 
         Enum.each(files, fn
-          {file_name, content, source_url, _download_url} ->
+          {file_name, content, source_url, download_url, thumbnail_url} ->
             bot_send_file(chat_id, file_name, content,
               source_url: source_url,
+              download_url: download_url,
+              thumbnail_url: thumbnail_url,
               source_chat: source_chat,
-              caption: caption
+              caption: caption,
+              message_thread_id: message_thread_id
+            )
+
+          {file_name, content, source_url, download_url} ->
+            bot_send_file(chat_id, file_name, content,
+              source_url: source_url,
+              download_url: download_url,
+              source_chat: source_chat,
+              caption: caption,
+              message_thread_id: message_thread_id
             )
 
           {file_name, content, source_url} ->
             bot_send_file(chat_id, file_name, content,
               source_url: source_url,
               source_chat: source_chat,
-              caption: caption
+              caption: caption,
+              message_thread_id: message_thread_id
             )
 
           {file_name, content} ->
-            bot_send_file(chat_id, file_name, content, source_chat: source_chat, caption: caption)
+            bot_send_file(chat_id, file_name, content,
+              source_chat: source_chat,
+              caption: caption,
+              message_thread_id: message_thread_id
+            )
         end)
     end
   end
@@ -975,7 +1176,10 @@ defmodule SaveIt.Bot do
 
     caption = Keyword.get(opts, :caption, "")
     source_url = Keyword.get(opts, :source_url)
+    download_url = Keyword.get(opts, :download_url)
+    thumbnail_url = Keyword.get(opts, :thumbnail_url)
     source_chat = Keyword.get(opts, :source_chat) || %{id: chat_id}
+    message_thread_id = Keyword.get(opts, :message_thread_id)
 
     if telegram_upload_too_large?(content) do
       send_message(chat_id, @telegram_file_too_large_message)
@@ -984,7 +1188,10 @@ defmodule SaveIt.Bot do
       do_bot_send_file(chat_id, file_name, content,
         caption: caption,
         source_url: source_url,
-        source_chat: source_chat
+        download_url: download_url,
+        thumbnail_url: thumbnail_url,
+        source_chat: source_chat,
+        message_thread_id: message_thread_id
       )
     end
   end
@@ -992,11 +1199,15 @@ defmodule SaveIt.Bot do
   defp do_bot_send_file(chat_id, file_name, content, opts) do
     caption = Keyword.fetch!(opts, :caption)
     source_url = Keyword.get(opts, :source_url)
+    download_url = Keyword.get(opts, :download_url)
+    thumbnail_url = Keyword.get(opts, :thumbnail_url)
     source_chat = Keyword.fetch!(opts, :source_chat)
+    message_thread_id = Keyword.get(opts, :message_thread_id)
 
     case file_extension(file_name) do
       ext when ext in [".png", ".jpg", ".jpeg"] ->
-        {:ok, msg} = ExGram.send_photo(chat_id, content, caption: caption)
+        {:ok, msg} =
+          ExGram.send_photo(chat_id, content, telegram_send_opts(caption, message_thread_id))
 
         file_id = get_file_id(msg)
 
@@ -1010,7 +1221,9 @@ defmodule SaveIt.Bot do
           url: source_url,
           belongs_to_id: chat_id
         }
-        |> Map.merge(source_message_fields(source_chat, message_id(msg)))
+        |> put_optional(:download_url, download_url)
+        |> put_optional(:thumbnail_url, thumbnail_url)
+        |> Map.merge(source_message_fields(source_chat, msg))
         |> safe_index_photo()
 
       ".mp4" ->
@@ -1019,12 +1232,14 @@ defmodule SaveIt.Bot do
         case ExGram.send_video(
                chat_id,
                prepared_content,
-               video_send_opts(caption, video_metadata)
+               video_send_opts(caption, video_metadata, message_thread_id)
              ) do
           {:ok, msg} = response ->
             index_sent_video_preview(chat_id, msg,
               caption: caption,
               source_url: source_url,
+              download_url: download_url,
+              thumbnail_url: thumbnail_url,
               source_chat: source_chat
             )
 
@@ -1035,18 +1250,24 @@ defmodule SaveIt.Bot do
         end
 
       ".gif" ->
-        ExGram.send_animation(chat_id, content, caption: caption)
+        ExGram.send_animation(chat_id, content, telegram_send_opts(caption, message_thread_id))
 
       _ ->
-        ExGram.send_document(chat_id, content, caption: caption)
+        ExGram.send_document(chat_id, content, telegram_send_opts(caption, message_thread_id))
     end
   end
 
-  defp video_send_opts(caption, video_metadata) do
+  defp telegram_send_opts(caption, message_thread_id) do
+    [caption: caption]
+    |> put_optional_keyword(:message_thread_id, message_thread_id)
+  end
+
+  defp video_send_opts(caption, video_metadata, message_thread_id) do
     [supports_streaming: true, caption: caption]
     |> maybe_put_video_metadata(:width, video_metadata)
     |> maybe_put_video_metadata(:height, video_metadata)
     |> maybe_put_video_metadata(:duration, video_metadata)
+    |> put_optional_keyword(:message_thread_id, message_thread_id)
   end
 
   defp maybe_put_video_metadata(opts, key, metadata) when is_map(metadata) do
@@ -1059,10 +1280,13 @@ defmodule SaveIt.Bot do
   defp index_sent_video_preview(chat_id, msg, opts) do
     caption = Keyword.fetch!(opts, :caption)
     source_url = Keyword.get(opts, :source_url)
+    download_url = Keyword.get(opts, :download_url)
+    thumbnail_url = Keyword.get(opts, :thumbnail_url)
     source_chat = Keyword.fetch!(opts, :source_chat)
 
     with file_id when is_binary(file_id) <- sent_video_file_id(msg),
-         {:ok, %DownloadedFile{} = file} <- download_sent_video_preview(msg, source_url) do
+         {:ok, %DownloadedFile{} = file} <-
+           download_sent_video_preview(msg, source_url, thumbnail_url) do
       %{
         image: Base.encode64(file.file_content),
         caption: caption,
@@ -1071,7 +1295,9 @@ defmodule SaveIt.Bot do
         url: source_url,
         belongs_to_id: chat_id
       }
-      |> Map.merge(source_message_fields(source_chat, message_id(msg)))
+      |> put_optional(:download_url, download_url)
+      |> put_optional(:thumbnail_url, thumbnail_url)
+      |> Map.merge(source_message_fields(source_chat, msg))
       |> safe_index_photo()
 
       store_sent_video_preview(file, source_url)
@@ -1086,12 +1312,19 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp download_sent_video_preview(msg, source_url) do
+  defp download_sent_video_preview(msg, source_url, thumbnail_url) do
     case download_message_thumbnail(msg) do
       {:ok, %DownloadedFile{} = file} -> {:ok, file}
-      {:error, _reason} -> LinkPreview.download_image(source_url)
+      {:error, _reason} -> download_preview_image(thumbnail_url, source_url)
     end
   end
+
+  defp download_preview_image(thumbnail_url, _source_url) when is_binary(thumbnail_url) do
+    WebDownloader.download_file(thumbnail_url)
+  end
+
+  defp download_preview_image(_thumbnail_url, source_url),
+    do: LinkPreview.download_image(source_url)
 
   defp store_sent_video_preview(%DownloadedFile{} = file, source_url) do
     cache_url = file.download_url || source_url
@@ -1173,17 +1406,31 @@ defmodule SaveIt.Bot do
     Map.get(message, :message_id) || Map.get(message, "message_id")
   end
 
-  defp message_id(_message), do: nil
-
-  defp source_message_fields(chat, message_id) when is_integer(message_id) do
-    %{}
-    |> Map.put(:source_message_id, message_id)
-    |> put_optional(:source_message_url, telegram_message_url(chat, message_id))
+  defp message_thread_id(message) when is_map(message) do
+    Map.get(message, :message_thread_id) || Map.get(message, "message_thread_id")
   end
 
-  defp source_message_fields(_chat, _message_id), do: %{}
+  defp source_message_fields(chat, message) when is_map(message) do
+    source_message_fields(chat, message_id(message), message_thread_id(message))
+  end
 
-  defp telegram_message_url(chat, message_id) do
+  defp source_message_fields(chat, message_id) when is_integer(message_id) do
+    source_message_fields(chat, message_id, nil)
+  end
+
+  defp source_message_fields(_chat, _message), do: %{}
+
+  defp source_message_fields(chat, message_id, message_thread_id) when is_integer(message_id) do
+    %{}
+    |> put_optional(
+      :source_message_url,
+      telegram_message_url(chat, message_id, message_thread_id)
+    )
+  end
+
+  defp source_message_fields(_chat, _message_id, _message_thread_id), do: %{}
+
+  defp telegram_message_url(chat, message_id, message_thread_id) do
     username = map_value(chat, :username)
     chat_id = map_value(chat, :id)
     private_channel_id = telegram_private_channel_id(chat_id)
@@ -1191,6 +1438,9 @@ defmodule SaveIt.Bot do
     cond do
       is_binary(username) and username != "" ->
         "https://t.me/#{username}/#{message_id}"
+
+      private_channel_id && is_integer(message_thread_id) ->
+        "https://t.me/c/#{private_channel_id}/#{message_thread_id}/#{message_id}"
 
       private_channel_id ->
         "https://t.me/c/#{private_channel_id}/#{message_id}"
@@ -1213,6 +1463,9 @@ defmodule SaveIt.Bot do
 
   defp put_optional(map, _key, nil), do: map
   defp put_optional(map, key, value), do: Map.put(map, key, value)
+
+  defp put_optional_keyword(keyword, _key, nil), do: keyword
+  defp put_optional_keyword(keyword, key, value), do: Keyword.put(keyword, key, value)
 
   defp safe_index_photo(photo_params) do
     case safe_typesense_create_photo(photo_params) do

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -1431,11 +1431,15 @@ defmodule SaveIt.Bot do
   defp source_message_fields(_chat, _message_id, _message_thread_id), do: %{}
 
   defp telegram_message_url(chat, message_id, message_thread_id) do
+    chat_type = map_value(chat, :type)
     username = map_value(chat, :username)
     chat_id = map_value(chat, :id)
     private_channel_id = telegram_private_channel_id(chat_id)
 
     cond do
+      chat_type == "private" ->
+        nil
+
       is_binary(username) and username != "" ->
         "https://t.me/#{username}/#{message_id}"
 

--- a/lib/save_it/photo_service.ex
+++ b/lib/save_it/photo_service.ex
@@ -212,7 +212,7 @@ defmodule SaveIt.PhotoService do
   end
 
   defp normalize_photo_urls(photo_params) do
-    Enum.reduce([:url, :download_url], photo_params, &normalize_photo_url_field/2)
+    Enum.reduce([:url, :download_url, :thumbnail_url], photo_params, &normalize_photo_url_field/2)
   end
 
   defp normalize_photo_url_field(field, acc) do

--- a/lib/small_sdk/link_preview.ex
+++ b/lib/small_sdk/link_preview.ex
@@ -1,6 +1,8 @@
 defmodule SmallSdk.LinkPreview do
   @moduledoc false
 
+  require Logger
+
   alias SmallSdk.WebDownloader
 
   @preview_patterns [
@@ -20,6 +22,11 @@ defmodule SmallSdk.LinkPreview do
     ~r/<meta[^>]+(?:content|value)=["']([^"']+)["'][^>]+name=["']description["']/i
   ]
 
+  @title_patterns [
+    ~r/<meta[^>]+property=["']og:title["'][^>]+(?:content|value)=["']([^"']+)["']/i,
+    ~r/<meta[^>]+(?:content|value)=["']([^"']+)["'][^>]+property=["']og:title["']/i
+  ]
+
   def download_image(page_url) when is_binary(page_url) do
     case get_image_url(page_url) do
       {:ok, image_url} -> WebDownloader.download_file(image_url)
@@ -30,24 +37,41 @@ defmodule SmallSdk.LinkPreview do
   def download_image(_page_url), do: {:error, :missing_preview_url}
 
   def get_image_url(page_url) when is_binary(page_url) do
-    case Req.get(page_url, headers: [{"User-Agent", "Mozilla/5.0"}]) do
-      {:ok, %{status: status, body: body}} when status in 200..209 and is_binary(body) ->
-        get_image_url_from_html(page_url, body)
-
-      {:ok, %{status: status}} ->
-        {:error, {:preview_page_status, status}}
-
-      {:error, reason} ->
-        {:error, reason}
+    case get_metadata(page_url) do
+      {:ok, %{image_url: image_url}} when is_binary(image_url) -> {:ok, image_url}
+      {:ok, _metadata} -> {:error, :no_preview_image}
+      {:error, reason} -> {:error, reason}
     end
   end
 
   def get_image_url(_page_url), do: {:error, :missing_preview_url}
 
   def get_description(page_url) when is_binary(page_url) do
+    case get_metadata(page_url) do
+      {:ok, %{description: description}} when is_binary(description) -> {:ok, description}
+      {:ok, _metadata} -> {:error, :no_preview_description}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def get_description(_page_url), do: {:error, :missing_preview_url}
+
+  def get_title(page_url) when is_binary(page_url) do
+    case get_metadata(page_url) do
+      {:ok, %{title: title}} when is_binary(title) -> {:ok, title}
+      {:ok, _metadata} -> {:error, :no_preview_title}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def get_title(_page_url), do: {:error, :missing_preview_url}
+
+  def get_metadata(page_url) when is_binary(page_url) do
     case Req.get(page_url, headers: [{"User-Agent", "Mozilla/5.0"}]) do
       {:ok, %{status: status, body: body}} when status in 200..209 and is_binary(body) ->
-        get_description_from_html(body)
+        metadata = get_metadata_from_html(page_url, body)
+        log_metadata(page_url, metadata)
+        {:ok, metadata}
 
       {:ok, %{status: status}} ->
         {:error, {:preview_page_status, status}}
@@ -57,7 +81,16 @@ defmodule SmallSdk.LinkPreview do
     end
   end
 
-  def get_description(_page_url), do: {:error, :missing_preview_url}
+  def get_metadata(_page_url), do: {:error, :missing_preview_url}
+
+  def get_metadata_from_html(page_url, html) when is_binary(page_url) and is_binary(html) do
+    %{
+      title: html |> extract_title() |> blank_to_nil(),
+      description: html |> extract_description() |> blank_to_nil(),
+      image_url:
+        html |> extract_image_url() |> resolve_image_url_value(page_url) |> blank_to_nil()
+    }
+  end
 
   def get_image_url_from_html(page_url, html) when is_binary(page_url) and is_binary(html) do
     html
@@ -69,6 +102,13 @@ defmodule SmallSdk.LinkPreview do
     case extract_description(html) do
       description when is_binary(description) and description != "" -> {:ok, description}
       _ -> {:error, :no_preview_description}
+    end
+  end
+
+  def get_title_from_html(html) when is_binary(html) do
+    case extract_title(html) do
+      title when is_binary(title) and title != "" -> {:ok, title}
+      _ -> {:error, :no_preview_title}
     end
   end
 
@@ -88,6 +128,74 @@ defmodule SmallSdk.LinkPreview do
         _ -> nil
       end
     end)
+  end
+
+  defp extract_title(html) do
+    Enum.find_value(@title_patterns, fn pattern ->
+      case Regex.run(pattern, html) do
+        [_, title] -> normalize_html_value(title)
+        _ -> nil
+      end
+    end)
+  end
+
+  defp resolve_image_url_value(nil, _page_url), do: nil
+
+  defp resolve_image_url_value(image_url, page_url) do
+    case resolve_image_url(image_url, page_url) do
+      {:ok, url} -> url
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp blank_to_nil(value) when is_binary(value) do
+    if value == "", do: nil, else: value
+  end
+
+  defp blank_to_nil(value), do: value
+
+  defp log_metadata(page_url, metadata) do
+    Logger.info(
+      "Link preview metadata fetched: " <>
+        "page_url=#{format_log_url(page_url)} " <>
+        "og_title=#{format_log_value(metadata.title)} " <>
+        "og_description=#{format_log_value(metadata.description)} " <>
+        "og_image=#{format_log_url(metadata.image_url)}",
+      kind: :link_preview
+    )
+  end
+
+  defp format_log_url(nil), do: "nil"
+
+  defp format_log_url(url) when is_binary(url) do
+    url
+    |> remove_query_and_fragment()
+    |> format_log_value()
+  end
+
+  defp format_log_value(nil), do: "nil"
+
+  defp format_log_value(value) when is_binary(value) do
+    value
+    |> truncate_log_value()
+    |> inspect()
+  end
+
+  defp truncate_log_value(value) do
+    if String.length(value) > 160 do
+      String.slice(value, 0, 160) <> "..."
+    else
+      value
+    end
+  end
+
+  defp remove_query_and_fragment(url) do
+    uri = URI.parse(url)
+
+    %URI{uri | query: nil, fragment: nil}
+    |> URI.to_string()
+  rescue
+    _ -> url
   end
 
   defp resolve_image_url(nil, _page_url), do: {:error, :no_preview_image}

--- a/lib/small_sdk/link_preview.ex
+++ b/lib/small_sdk/link_preview.ex
@@ -74,9 +74,12 @@ defmodule SmallSdk.LinkPreview do
         {:ok, metadata}
 
       {:ok, %{status: status}} ->
-        {:error, {:preview_page_status, status}}
+        reason = {:preview_page_status, status}
+        log_metadata_error(page_url, reason)
+        {:error, reason}
 
       {:error, reason} ->
+        log_metadata_error(page_url, reason)
         {:error, reason}
     end
   end
@@ -165,6 +168,15 @@ defmodule SmallSdk.LinkPreview do
     )
   end
 
+  defp log_metadata_error(page_url, reason) do
+    Logger.warning(
+      "Link preview metadata fetch failed: " <>
+        "page_url=#{format_log_url(page_url)} " <>
+        "reason=#{format_log_reason(reason)}",
+      kind: :link_preview
+    )
+  end
+
   defp format_log_url(nil), do: "nil"
 
   defp format_log_url(url) when is_binary(url) do
@@ -179,6 +191,12 @@ defmodule SmallSdk.LinkPreview do
     value
     |> truncate_log_value()
     |> inspect()
+  end
+
+  defp format_log_reason(reason) do
+    reason
+    |> inspect()
+    |> truncate_log_value()
   end
 
   defp truncate_log_value(value) do

--- a/lib/small_sdk/telegram.ex
+++ b/lib/small_sdk/telegram.ex
@@ -9,8 +9,9 @@ defmodule SmallSdk.Telegram do
     token = get_env()
     path = "/bot#{token}/sendMediaGroup"
     caption = Keyword.get(opts, :caption, "")
+    message_thread_id = Keyword.get(opts, :message_thread_id)
 
-    {media_entries, multipart_fields} =
+    {media_entries, file_fields} =
       files
       |> Enum.with_index()
       |> Enum.reduce({[], []}, fn {file, index}, {media_acc, fields_acc} ->
@@ -39,11 +40,9 @@ defmodule SmallSdk.Telegram do
     media_json = media_entries |> Enum.reverse() |> Jason.encode!()
 
     multipart_fields =
-      [
-        {"chat_id", to_string(chat_id)},
-        {"media", media_json}
-        | Enum.reverse(multipart_fields)
-      ]
+      [{"chat_id", to_string(chat_id)}]
+      |> maybe_append_multipart_field("message_thread_id", message_thread_id)
+      |> Kernel.++([{"media", media_json} | Enum.reverse(file_fields)])
 
     path
     |> build_request()
@@ -63,6 +62,12 @@ defmodule SmallSdk.Telegram do
   defp put_caption(media, ""), do: media
   defp put_caption(media, nil), do: media
   defp put_caption(media, caption), do: Map.put(media, :caption, caption)
+
+  defp maybe_append_multipart_field(fields, _name, nil), do: fields
+  defp maybe_append_multipart_field(fields, name, value), do: fields ++ [{name, to_string(value)}]
+
+  defp media_group_file_parts({file_name, content, _source_url, _download_url, _thumbnail_url}),
+    do: {file_name, content}
 
   defp media_group_file_parts({file_name, content, _source_url, _download_url}),
     do: {file_name, content}

--- a/priv/typesense/migrations/20260614000000_drop_source_message_id_from_photos.exs
+++ b/priv/typesense/migrations/20260614000000_drop_source_message_id_from_photos.exs
@@ -1,0 +1,29 @@
+defmodule SaveIt.Typesense.Migrations.DropSourceMessageIdFromPhotos20260614000000 do
+  @moduledoc false
+
+  alias SmallSdk.TypesenseMigration
+
+  @collection_name "photos"
+  @field %{"name" => "source_message_id", "type" => "int64", "optional" => true}
+
+  def version, do: "20260614000000"
+  def name, do: "drop_source_message_id_from_photos"
+
+  def up do
+    if TypesenseMigration.has_field?(@collection_name, @field["name"]) do
+      TypesenseMigration.update_collection!(@collection_name, %{
+        "fields" => [%{"name" => @field["name"], "drop" => true}]
+      })
+    end
+  end
+
+  def down do
+    unless TypesenseMigration.has_field?(@collection_name, @field["name"]) do
+      TypesenseMigration.update_collection!(@collection_name, %{"fields" => [@field]})
+    end
+  end
+
+  def applied? do
+    not TypesenseMigration.has_field?(@collection_name, @field["name"])
+  end
+end

--- a/priv/typesense/migrations/20260614001000_add_thumbnail_url_to_photos.exs
+++ b/priv/typesense/migrations/20260614001000_add_thumbnail_url_to_photos.exs
@@ -1,0 +1,43 @@
+defmodule SaveIt.Typesense.Migrations.AddThumbnailUrlToPhotos20260614001000 do
+  @moduledoc false
+
+  alias SmallSdk.TypesenseMigration
+
+  @collection_name "photos"
+  @field %{"name" => "thumbnail_url", "type" => "string", "optional" => true}
+
+  def version, do: "20260614001000"
+  def name, do: "add_thumbnail_url_to_photos"
+
+  def up do
+    case TypesenseMigration.field(@collection_name, @field["name"]) do
+      nil ->
+        TypesenseMigration.update_collection!(@collection_name, %{"fields" => [@field]})
+
+      %{"optional" => true} ->
+        :ok
+
+      _field ->
+        TypesenseMigration.update_collection!(@collection_name, %{
+          "fields" => [%{"name" => @field["name"], "drop" => true}]
+        })
+
+        TypesenseMigration.update_collection!(@collection_name, %{"fields" => [@field]})
+    end
+  end
+
+  def down do
+    if TypesenseMigration.has_field?(@collection_name, @field["name"]) do
+      TypesenseMigration.update_collection!(@collection_name, %{
+        "fields" => [%{"name" => @field["name"], "drop" => true}]
+      })
+    end
+  end
+
+  def applied? do
+    case TypesenseMigration.field(@collection_name, @field["name"]) do
+      %{"optional" => true} -> true
+      _field -> false
+    end
+  end
+end

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -93,11 +93,11 @@ defmodule SaveIt.BotTest do
     document = Jason.decode!(typesense_body)
 
     assert document["url"] == original_url
-    refute Map.has_key?(document, "download_url")
+    assert document["download_url"] == download_url
     assert document["caption"] == "summer reference"
     assert document["file_id"] == "telegram-photo-file-id"
     assert document["belongs_to_id"] == "12345"
-    assert document["source_message_id"] == 20
+    refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_test_chat/20"
 
     assert Enum.any?(exgram_calls(), fn
@@ -139,7 +139,161 @@ defmodule SaveIt.BotTest do
 
     document = Jason.decode!(typesense_body)
 
+    assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    assert document["thumbnail_url"] == base_url <> "/preview.jpg"
     assert document["caption"] == "Photo Page OG Description"
+  end
+
+  test "uses the x.com URL og description as the caption when user text only contains the URL",
+       %{base_url: base_url} do
+    original_url = "https://x.com/example/status/1?utm_source=telegram"
+    download_url = base_url <> "/downloaded/photo.jpg"
+    preview_url = base_url <> "/x-page"
+
+    message = %{
+      chat: %{id: 12_345, username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 98,
+      text: original_url,
+      link_preview_options: %{url: preview_url}
+    }
+
+    assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => "https://x.com/example/status/1"}
+    assert_receive {:test_http_request, :get, "/x-page", ""}
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    assert document["thumbnail_url"] == base_url <> "/preview.jpg"
+    assert document["caption"] == "X Page OG Description"
+
+    assert Enum.any?(exgram_calls(), fn
+             {:post, :send_photo, {:multipart, parts}} ->
+               {"caption", "X Page OG Description"} in parts
+
+             _ ->
+               false
+           end)
+  end
+
+  test "sends downloaded URL media to the source topic and stores a topic message URL",
+       %{base_url: base_url} do
+    Application.put_env(:ex_gram, :adapter, __MODULE__.TopicSendPhotoAdapter)
+
+    chat_id = -1_001_234_567_890
+    original_url = "https://x.com/example/status/1?utm_source=telegram"
+    download_url = base_url <> "/downloaded/photo.jpg"
+    preview_url = base_url <> "/x-page"
+
+    message = %{
+      chat: %{id: chat_id},
+      date: 1_717_170_000,
+      message_id: 99,
+      message_thread_id: 42,
+      text: original_url,
+      link_preview_options: %{url: preview_url}
+    }
+
+    assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendPhoto", {:multipart, parts}}
+    assert multipart_part(parts, "chat_id") == Integer.to_string(chat_id)
+    assert multipart_part(parts, "message_thread_id") == "42"
+    assert multipart_part(parts, "caption") == "X Page OG Description"
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    refute Map.has_key?(document, "source_message_id")
+    assert document["download_url"] == download_url
+    assert document["source_message_url"] == "https://t.me/c/1234567890/42/77"
+  end
+
+  test "falls back to the x.com URL og title as caption and logs preview metadata",
+       %{base_url: base_url} do
+    original_url = "https://x.com/example/status/1?utm_source=telegram"
+    preview_url = base_url <> "/x-title-only-page"
+
+    message = %{
+      chat: %{id: 12_345, username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 101,
+      text: original_url,
+      link_preview_options: %{url: preview_url}
+    }
+
+    log =
+      capture_log(fn ->
+        assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+      end)
+
+    assert log =~ "Link preview metadata fetched"
+    assert log =~ "og_title=\"X Title Only Page OG Title\""
+    assert log =~ "og_description=nil"
+    assert log =~ "og_image=\"#{base_url}/preview.jpg\""
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => "https://x.com/example/status/1"}
+    assert_receive {:test_http_request, :get, "/x-title-only-page", ""}
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["caption"] == "X Title Only Page OG Title"
+
+    assert Enum.any?(exgram_calls(), fn
+             {:post, :send_photo, {:multipart, parts}} ->
+               {"caption", "X Title Only Page OG Title"} in parts
+
+             _ ->
+               false
+           end)
+  end
+
+  test "uses the youtube.com URL og title as the caption when user text only contains the URL",
+       %{base_url: base_url} do
+    original_url = "https://www.youtube.com/shorts/clip123"
+    preview_url = base_url <> "/youtube-page"
+
+    Application.put_env(:ex_gram, :adapter, __MODULE__.UrlVideoThumbnailAdapter)
+    Application.put_env(:save_it, :video_metadata_probe, __MODULE__.VideoMetadataProbe)
+
+    message = %{
+      chat: %{id: 12_345, username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 100,
+      text: original_url,
+      link_preview_options: %{url: preview_url}
+    }
+
+    assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => original_url}
+    assert_receive {:test_http_request, :get, "/downloaded/video.mp4", ""}
+    assert_receive {:test_http_request, :get, "/youtube-page", ""}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendVideo", {:multipart, parts}}
+    assert multipart_part(parts, "caption") == "YouTube Page OG Title"
+
+    assert_receive {:exgram_request, :get, "/bottest-token/getFile",
+                    %{file_id: "sent-video-thumbnail-id"}}
+
+    assert_receive {:telegram_download_request, _telegram_env}
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["caption"] == "YouTube Page OG Title"
   end
 
   test "stores the Telegram thumbnail when a user-sent url cannot be resolved", _context do
@@ -185,9 +339,10 @@ defmodule SaveIt.BotTest do
 
     assert document["url"] == original_url
     refute Map.has_key?(document, "download_url")
+    refute Map.has_key?(document, "thumbnail_url")
     assert document["file_id"] == "telegram-photo-file-id"
     assert document["belongs_to_id"] == "12345"
-    assert document["source_message_id"] == 20
+    refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_test_chat/20"
 
     refute Enum.any?(exgram_calls(), fn
@@ -231,9 +386,10 @@ defmodule SaveIt.BotTest do
 
     assert document["url"] == original_url
     refute Map.has_key?(document, "download_url")
+    assert document["thumbnail_url"] == base_url <> "/preview.jpg"
     assert document["caption"] == "Preview Page OG Description"
     assert document["file_id"] == "telegram-photo-file-id"
-    assert document["source_message_id"] == 20
+    refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_test_chat/20"
 
     refute Enum.any?(exgram_calls(), fn
@@ -248,6 +404,7 @@ defmodule SaveIt.BotTest do
   test "indexes a downloaded URL video using the Telegram video thumbnail before the webpage preview",
        %{base_url: base_url} do
     original_url = base_url <> "/video-page-with-telegram-thumbnail"
+    download_url = base_url <> "/downloaded/video.mp4"
     message_text = "clip notes #{original_url}"
 
     Application.put_env(:ex_gram, :adapter, __MODULE__.UrlVideoThumbnailAdapter)
@@ -292,14 +449,16 @@ defmodule SaveIt.BotTest do
     document = Jason.decode!(typesense_body)
 
     assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    assert document["thumbnail_url"] == base_url <> "/video-preview.jpg"
     assert document["caption"] == "clip notes"
     assert document["file_id"] == "sent-video-file-id"
     assert document["media_type"] == "video"
     assert document["image"] == Base.encode64(test_jpeg())
-    assert document["source_message_id"] == 70
+    refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_test_chat/70"
 
-    refute_receive {:test_http_request, :get, "/video-page-with-telegram-thumbnail", ""}
+    assert_receive {:test_http_request, :get, "/video-page-with-telegram-thumbnail", ""}
     refute_receive {:test_http_request, :get, "/video-preview.jpg", ""}
     refute_receive {:test_http_request, :get, "/preview.jpg", ""}
 
@@ -312,6 +471,7 @@ defmodule SaveIt.BotTest do
     base_url: base_url
   } do
     original_url = base_url <> "/video-page"
+    download_url = base_url <> "/downloaded/video.mp4"
 
     Application.put_env(:ex_gram, :adapter, __MODULE__.UrlVideoWithoutThumbnailAdapter)
 
@@ -341,11 +501,13 @@ defmodule SaveIt.BotTest do
     document = Jason.decode!(typesense_body)
 
     assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    assert document["thumbnail_url"] == base_url <> "/video-preview.jpg"
     assert document["caption"] == "Video Page OG Description"
     assert document["file_id"] == "sent-video-file-id"
     assert document["media_type"] == "video"
     assert document["image"] == Base.encode64(test_og_jpeg())
-    assert document["source_message_id"] == 71
+    refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_test_chat/71"
 
     assert File.read(storage_file_path(cached_video_preview_name(base_url))) ==
@@ -380,6 +542,8 @@ defmodule SaveIt.BotTest do
     document = Jason.decode!(typesense_body)
 
     assert document["url"] == original_url
+    assert document["download_url"] == "https://stream.example/master.m3u8"
+    assert document["thumbnail_url"] == base_url <> "/video-preview.jpg"
     assert document["caption"] == "HLS Video Page OG Description"
     assert document["file_id"] == "sent-video-file-id"
     assert document["media_type"] == "video"
@@ -389,7 +553,9 @@ defmodule SaveIt.BotTest do
              {:ok, test_og_jpeg()}
   end
 
-  test "stores the original user-sent url for every photo in a multi-image download", _context do
+  test "stores the original user-sent url for every photo in a multi-image download", %{
+    base_url: base_url
+  } do
     original_url = "https://x.com/JennerItGirls/status/2057529104535023815?s=20"
     message_text = "runway gallery #{original_url}"
     purge_url = "https://x.com/JennerItGirls/status/2057529104535023815"
@@ -439,7 +605,15 @@ defmodule SaveIt.BotTest do
 
     assert Enum.map(documents, & &1["url"]) == List.duplicate(original_url, 4)
     assert Enum.map(documents, & &1["caption"]) == List.duplicate("runway gallery", 4)
-    refute Enum.any?(documents, &Map.has_key?(&1, "download_url"))
+
+    assert documents
+           |> Enum.map(& &1["download_url"])
+           |> Enum.sort() == [
+             base_url <> "/downloaded/photo-1.jpg",
+             base_url <> "/downloaded/photo-2.jpg",
+             base_url <> "/downloaded/photo-3.jpg",
+             base_url <> "/downloaded/photo-4.jpg"
+           ]
 
     assert Enum.map(documents, & &1["file_id"]) == [
              "group-file-1",
@@ -448,7 +622,7 @@ defmodule SaveIt.BotTest do
              "group-file-4"
            ]
 
-    assert Enum.map(documents, & &1["source_message_id"]) == [101, 102, 103, 104]
+    refute Enum.any?(documents, &Map.has_key?(&1, "source_message_id"))
 
     assert Enum.map(documents, & &1["source_message_url"]) == [
              "https://t.me/save_it_test_chat/101",
@@ -733,7 +907,7 @@ defmodule SaveIt.BotTest do
     assert document["belongs_to_id"] == Integer.to_string(chat_id)
     assert document["media_type"] == "photo"
     assert document["image"] == Base.encode64(test_jpeg())
-    assert document["source_message_id"] == 321
+    refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_directs/321"
     refute Map.has_key?(document, "url")
     refute Map.has_key?(document, "download_url")
@@ -748,6 +922,43 @@ defmodule SaveIt.BotTest do
     assert binary_contains?(drive_body, ~s("name":"direct-photo.jpg"))
     assert binary_contains?(drive_body, "test-drive-folder")
     assert File.read(stored_file_path) == {:ok, test_jpeg()}
+  end
+
+  test "stores a private supergroup topic message URL for a directly uploaded photo", _context do
+    chat_id = -1_001_234_567_890
+    stored_file_path = storage_file_path("topic-direct-photo.jpg")
+
+    File.rm(stored_file_path)
+
+    Application.put_env(:save_it, :telegram_req_options,
+      adapter: &__MODULE__.TelegramDirectMediaAdapter.request/1
+    )
+
+    on_exit(fn ->
+      File.rm(stored_file_path)
+    end)
+
+    ExGramTestAdapter.backdoor_request(:get_file, %{
+      file_id: "uploaded-photo-file-id",
+      file_path: "photos/topic-direct-photo.jpg"
+    })
+
+    message = %{
+      chat: %{id: chat_id},
+      message_id: 654,
+      message_thread_id: 42,
+      caption: "topic image",
+      photo: [%{file_id: "uploaded-photo-file-id"}]
+    }
+
+    Bot.handle({:message, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    refute Map.has_key?(document, "source_message_id")
+    assert document["source_message_url"] == "https://t.me/c/1234567890/42/654"
   end
 
   test "stores a photo caption delivered as text by ExGram", _context do
@@ -785,7 +996,7 @@ defmodule SaveIt.BotTest do
     assert document["file_id"] == "uploaded-photo-file-id"
     assert document["belongs_to_id"] == Integer.to_string(chat_id)
     assert document["media_type"] == "photo"
-    assert document["source_message_id"] == 322
+    refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_directs/322"
   end
 
@@ -823,7 +1034,7 @@ defmodule SaveIt.BotTest do
     assert document["caption"] == ""
     assert document["file_id"] == "uploaded-photo-file-id"
     assert document["media_type"] == "photo"
-    assert document["source_message_id"] == 323
+    refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_directs/323"
   end
 
@@ -870,7 +1081,7 @@ defmodule SaveIt.BotTest do
     assert document["belongs_to_id"] == Integer.to_string(chat_id)
     assert document["media_type"] == "video"
     assert document["image"] == Base.encode64(test_jpeg())
-    assert document["source_message_id"] == 322
+    refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_directs/322"
 
     assert_receive {:google_drive_upload_request, drive_env}
@@ -1213,6 +1424,46 @@ defmodule SaveIt.BotTest do
     end
   end
 
+  defmodule TopicSendPhotoAdapter do
+    @behaviour ExGram.Adapter
+
+    @impl ExGram.Adapter
+    def request(verb, path, body, _opts) do
+      send(self(), {:exgram_request, verb, path, body})
+
+      case {verb, path, body} do
+        {:post, "/bottest-token/sendMessage", %{chat_id: chat_id}} ->
+          {:ok, %{message_id: 76, chat: %{id: chat_id}}}
+
+        {:post, "/bottest-token/editMessageText", _body} ->
+          {:ok, %{message_id: 76}}
+
+        {:post, "/bottest-token/deleteMessage", _body} ->
+          {:ok, true}
+
+        {:post, "/bottest-token/sendPhoto", {:multipart, parts}} ->
+          {:ok,
+           %{
+             message_id: 77,
+             message_thread_id:
+               multipart_value(parts, "message_thread_id") |> String.to_integer(),
+             chat: %{id: multipart_value(parts, "chat_id") |> String.to_integer()},
+             photo: [%{file_id: "topic-photo-file-id"}]
+           }}
+
+        _ ->
+          {:error, %ExGram.Error{code: 404}}
+      end
+    end
+
+    defp multipart_value(parts, name) do
+      Enum.find_value(parts, fn
+        {^name, value} -> value
+        _part -> nil
+      end)
+    end
+  end
+
   defmodule UrlVideoThumbnailAdapter do
     @behaviour ExGram.Adapter
 
@@ -1498,39 +1749,9 @@ defmodule SaveIt.BotTest do
     end
 
     defp response_for("/", port, body) do
-      case Jason.decode!(body) do
-        %{"url" => "https://x.com/example/status/1"} ->
-          json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg"})
-
-        %{"url" => "https://x.com/JennerItGirls/status/2057529104535023815"} ->
-          json_response(%{
-            "status" => "picker",
-            "picker" => [
-              %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-1.jpg"},
-              %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-2.jpg"},
-              %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-3.jpg"},
-              %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-4.jpg"}
-            ]
-          })
-
-        %{"url" => "https://example.com/unavailable"} ->
-          error_response(%{"error" => "unsupported url"})
-
-        %{"url" => "http://127.0.0.1:" <> _ = url} ->
-          cond do
-            String.contains?(url, "/photo-page") ->
-              json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg"})
-
-            String.contains?(url, "/video-page") ->
-              json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/video.mp4"})
-
-            true ->
-              error_response(%{"error" => "unsupported url"})
-          end
-
-        unexpected ->
-          raise "Unexpected cobalt request body: #{inspect(unexpected)}"
-      end
+      body
+      |> Jason.decode!()
+      |> cobalt_response(port)
     end
 
     defp response_for("/collections/photos/documents/search?" <> query, port, _body) do
@@ -1617,6 +1838,74 @@ defmodule SaveIt.BotTest do
           <meta property="og:image" content="http://127.0.0.1:#{port}/preview.jpg">
         </head>
         <body>preview</body>
+      </html>
+      """
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: text/html\r
+      content-length: #{byte_size(html)}\r
+      connection: close\r
+      \r
+      #{html}
+      """
+    end
+
+    defp response_for("/x-page", port, _body) do
+      html = """
+      <!doctype html>
+      <html>
+        <head>
+          <meta property="og:title" content="X Page OG Title">
+          <meta property="og:description" content="X Page OG Description">
+          <meta property="og:image" content="http://127.0.0.1:#{port}/preview.jpg">
+        </head>
+        <body>x preview</body>
+      </html>
+      """
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: text/html\r
+      content-length: #{byte_size(html)}\r
+      connection: close\r
+      \r
+      #{html}
+      """
+    end
+
+    defp response_for("/x-title-only-page", port, _body) do
+      html = """
+      <!doctype html>
+      <html>
+        <head>
+          <meta property="og:title" content="X Title Only Page OG Title">
+          <meta property="og:image" content="http://127.0.0.1:#{port}/preview.jpg">
+        </head>
+        <body>x title only preview</body>
+      </html>
+      """
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: text/html\r
+      content-length: #{byte_size(html)}\r
+      connection: close\r
+      \r
+      #{html}
+      """
+    end
+
+    defp response_for("/youtube-page", port, _body) do
+      html = """
+      <!doctype html>
+      <html>
+        <head>
+          <meta property="og:title" content="YouTube Page OG Title">
+          <meta property="og:description" content="YouTube Page OG Description">
+          <meta property="og:image" content="http://127.0.0.1:#{port}/video-preview.jpg">
+        </head>
+        <body>youtube preview</body>
       </html>
       """
 
@@ -1733,6 +2022,50 @@ defmodule SaveIt.BotTest do
       connection: close\r
       \r
       """
+    end
+
+    defp cobalt_response(%{"url" => "https://x.com/example/status/1"}, port) do
+      json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg"})
+    end
+
+    defp cobalt_response(
+           %{"url" => "https://x.com/JennerItGirls/status/2057529104535023815"},
+           port
+         ) do
+      json_response(%{
+        "status" => "picker",
+        "picker" => [
+          %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-1.jpg"},
+          %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-2.jpg"},
+          %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-3.jpg"},
+          %{"url" => "http://127.0.0.1:#{port}/downloaded/photo-4.jpg"}
+        ]
+      })
+    end
+
+    defp cobalt_response(%{"url" => "https://www.youtube.com/shorts/clip123"}, port) do
+      json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/video.mp4"})
+    end
+
+    defp cobalt_response(%{"url" => "https://example.com/unavailable"}, _port) do
+      error_response(%{"error" => "unsupported url"})
+    end
+
+    defp cobalt_response(%{"url" => "http://127.0.0.1:" <> _ = url}, port) do
+      cond do
+        String.contains?(url, "/photo-page") ->
+          json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg"})
+
+        String.contains?(url, "/video-page") ->
+          json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/video.mp4"})
+
+        true ->
+          error_response(%{"error" => "unsupported url"})
+      end
+    end
+
+    defp cobalt_response(unexpected, _port) do
+      raise "Unexpected cobalt request body: #{inspect(unexpected)}"
     end
 
     defp similar_hits("belongs_to_id:12346") do

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -110,6 +110,42 @@ defmodule SaveIt.BotTest do
            end)
   end
 
+  test "does not store a source message URL for private DM saves", %{base_url: base_url} do
+    original_url = "https://x.com/example/status/1?utm_source=telegram"
+    message_text = "dm reference #{original_url}"
+    download_url = base_url <> "/downloaded/photo.jpg"
+    cached_file_name = "bot-private-dm-source-url-test.jpg"
+    cached_file_content = <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70>>
+
+    FileHelper.write_file(cached_file_name, cached_file_content, download_url)
+
+    on_exit(fn ->
+      cleanup_cached_file(download_url, cached_file_name)
+    end)
+
+    message = %{
+      chat: %{id: 12_345, type: "private", username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 100,
+      text: message_text
+    }
+
+    assert {:ok, true} = Bot.handle({:text, message_text, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => "https://x.com/example/status/1"}
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    assert document["caption"] == "dm reference"
+    refute Map.has_key?(document, "source_message_id")
+    refute Map.has_key?(document, "source_message_url")
+  end
+
   test "uses the URL og description as the caption when user text only contains the URL", %{
     base_url: base_url
   } do

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -294,6 +294,39 @@ defmodule SaveIt.BotTest do
            end)
   end
 
+  test "logs link preview metadata fetch failures", %{base_url: base_url} do
+    original_url = "https://x.com/example/status/1"
+    preview_url = base_url <> "/missing-preview-page"
+
+    message = %{
+      chat: %{id: 12_345, username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 102,
+      text: original_url,
+      link_preview_options: %{url: preview_url}
+    }
+
+    log =
+      capture_log(fn ->
+        assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+      end)
+
+    assert log =~ "Link preview metadata fetch failed"
+    assert log =~ "page_url=\"#{preview_url}\""
+    assert log =~ "reason={:preview_page_status, 404}"
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => original_url}
+    assert_receive {:test_http_request, :get, "/downloaded/photo.jpg", ""}
+    assert_receive {:test_http_request, :get, "/missing-preview-page", ""}
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["caption"] == ""
+    refute Map.has_key?(document, "thumbnail_url")
+  end
+
   test "uses the youtube.com URL og title as the caption when user text only contains the URL",
        %{base_url: base_url} do
     original_url = "https://www.youtube.com/shorts/clip123"

--- a/test/small_sdk/link_preview_test.exs
+++ b/test/small_sdk/link_preview_test.exs
@@ -46,4 +46,34 @@ defmodule SmallSdk.LinkPreviewTest do
 
     assert LinkPreview.get_description_from_html(html) == {:ok, "Photo Page OG Description"}
   end
+
+  test "extracts an og title" do
+    html = """
+    <html>
+      <head>
+        <meta property="og:title" content="YouTube Page OG Title" />
+      </head>
+    </html>
+    """
+
+    assert LinkPreview.get_title_from_html(html) == {:ok, "YouTube Page OG Title"}
+  end
+
+  test "extracts preview metadata from html" do
+    html = """
+    <html>
+      <head>
+        <meta property="og:title" content="Preview Page OG Title" />
+        <meta property="og:description" content="Preview Page OG Description" />
+        <meta property="og:image" content="/preview.jpg" />
+      </head>
+    </html>
+    """
+
+    assert LinkPreview.get_metadata_from_html("https://example.com/posts/1", html) == %{
+             title: "Preview Page OG Title",
+             description: "Preview Page OG Description",
+             image_url: "https://example.com/preview.jpg"
+           }
+  end
 end

--- a/test/small_sdk/telegram_test.exs
+++ b/test/small_sdk/telegram_test.exs
@@ -28,7 +28,8 @@ defmodule SmallSdk.TelegramTest do
                [
                  {"photo.jpg", {:file_content, <<1, 2, 3>>, "photo.jpg"}, "https://x.com/example"}
                ],
-               caption: "created at 2024-06-01"
+               caption: "created at 2024-06-01",
+               message_thread_id: 42
              )
 
     assert_receive {:telegram_request, env}
@@ -38,6 +39,8 @@ defmodule SmallSdk.TelegramTest do
 
     assert multipart =~ ~s(name="chat_id")
     assert multipart =~ "123"
+    assert multipart =~ ~s(name="message_thread_id")
+    assert multipart =~ "42"
 
     assert multipart =~ ~s(name="media0"; filename="photo.jpg")
     assert multipart =~ <<1, 2, 3>>


### PR DESCRIPTION
## Summary

- Store URL media `download_url` and public `thumbnail_url` metadata in Typesense across photo, video, HLS, and multi-image save flows.
- Improve link preview metadata extraction/logging and caption fallback behavior for X/Twitter and YouTube links.
- Log link preview metadata fetch failures, including sanitized preview URL and reason, so missing URL captions/thumbnails can be diagnosed from runtime logs.
- Preserve source Telegram topic URLs while removing the unused `source_message_id` field from Typesense.
- Stop storing invalid `source_message_url` values for private DM saves because Telegram does not provide an official direct URL to a specific DM message.
- Update the local worktree setup skill and add postmortems for the fixed metadata issues.

## Why

Successful URL saves were uploading media and indexing searchable thumbnails, but important metadata was dropped before the Typesense document was created. This made it hard to inspect the resolved media URL, the public preview image URL, and the correct source message link from Typesense/typelens.

The latest X URL investigation showed another boundary: Cobalt cookies can resolve and download media, while the bot's separate Open Graph request can still fail. For `https://x.com/wes_helton9/status/2065783860730986919?s=20`, `SmallSdk.LinkPreview.get_metadata/1` returned `{:error, {:preview_page_status, 404}}`; without failure logs, runtime output only showed the successful download path.

The private DM case needed a separate boundary: Telegram official deep links document message links for public/private groups and channels, while user links only open a chat/profile. A private bot DM may have a username, but `https://t.me/<username>/<message_id>` is not a valid jump link to a specific DM message.

Reference: https://core.telegram.org/api/links#message-links

## Validation

- `mix checks`
- `mix test`
- `git diff --check`
- `mix test test/bot_test.exs test/small_sdk/link_preview_test.exs`
