### PR TITLE
refactor: reduce runtime log noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Changed
+
+- Keep ordinary informational logs uncolored and reserve green logs for successful resource creation events.
+
 ### Fixed
 
 - Fix Zeabur Cobalt cookie setup to use a file config at `/cookies.json` instead of mounting a volume as a file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ before the CalVer migration retain their original version labels.
 ### Changed
 
 - Keep ordinary informational logs uncolored and reserve green logs for successful resource creation events.
-- Use YouTube Open Graph titles as captions for URL-only saves, keep X captions based on Open Graph descriptions with title fallback, and log fetched link preview metadata.
+- Reduce default runtime log noise by moving successful intermediate download, file-write, link-preview, search, and video-probing details out of the normal log stream.
+- Use YouTube Open Graph titles as captions for URL-only saves, and keep X captions based on Open Graph descriptions with title fallback.
 
 ### Fixed
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,8 @@ config :logger, :default_formatter,
   colors: [
     enabled: true,
     debug: :cyan,
-    info: :green,
+    info: :normal,
+    notice: :green,
     warning: :yellow,
     error: :red
   ]

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -218,7 +218,7 @@ defmodule SaveIt.Bot do
   end
 
   def handle({:edited_message, %{photo: nil}}, _context) do
-    Logger.warning("this is an edited message, ignore it")
+    Logger.debug("Ignoring edited message without photo")
     # Edited search commands are ignored for now.
     {:ok, nil}
   end
@@ -229,12 +229,12 @@ defmodule SaveIt.Bot do
   end
 
   def handle({:update, _update}, _context) do
-    Logger.warning("this is an update, ignore it")
+    Logger.debug("Ignoring unsupported update")
     {:ok, nil}
   end
 
   def handle({:message, _message}, _context) do
-    Logger.warning("this is a message, ignore it")
+    Logger.debug("Ignoring unsupported message")
     {:ok, nil}
   end
 
@@ -389,6 +389,16 @@ defmodule SaveIt.Bot do
     else
       :ok
     end
+  end
+
+  defp log_resource_created(source, %DownloadedFile{file_name: file_name}) do
+    Logger.notice("resource_created source=#{source} file_name=#{file_name}", kind: :resource)
+  end
+
+  defp log_resources_created(source, files) when is_list(files) do
+    Logger.notice("resource_created source=#{source} file_count=#{length(files)}",
+      kind: :resource
+    )
   end
 
   defp video_thumbnail(video) do
@@ -591,6 +601,7 @@ defmodule SaveIt.Bot do
         delete_message(context.chat_id, context.progress_message_id)
         FileHelper.write_folder(context.purge_url, files)
         GoogleDrive.upload_files(context.chat_id, files)
+        log_resources_created(:url_download, files)
         :ok
 
       {:error, reason} ->
@@ -819,6 +830,7 @@ defmodule SaveIt.Bot do
     delete_message(context.chat_id, context.progress_message_id)
     FileHelper.write_file(file.file_name, file.file_content, context.original_url)
     GoogleDrive.upload_file_content(context.chat_id, file.file_content, file.file_name)
+    log_resource_created(:thumbnail_fallback, file)
     :ok
   end
 
@@ -826,6 +838,7 @@ defmodule SaveIt.Bot do
     delete_message(context.chat_id, context.progress_message_id)
     FileHelper.write_file(file.file_name, file.file_content, context.cache_url)
     GoogleDrive.upload_file_content(context.chat_id, file.file_content, file.file_name)
+    log_resource_created(:url_download, file)
     :ok
   end
 
@@ -857,7 +870,7 @@ defmodule SaveIt.Bot do
   defp link_preview_caption(_message, original_url, metadata) when is_map(metadata) do
     case caption_from_link_preview_metadata(metadata, original_url) do
       {:ok, caption, source} ->
-        Logger.info("Link preview caption selected: source=#{source}", kind: :link_preview)
+        Logger.debug("Link preview caption selected: source=#{source}", kind: :link_preview)
         caption
 
       {:error, _reason} ->
@@ -879,7 +892,7 @@ defmodule SaveIt.Bot do
   defp fetch_link_preview_caption(preview_url, original_url) when is_binary(preview_url) do
     with {:ok, metadata} <- LinkPreview.get_metadata(preview_url),
          {:ok, caption, source} <- caption_from_link_preview_metadata(metadata, original_url) do
-      Logger.info("Link preview caption selected: source=#{source}", kind: :link_preview)
+      Logger.debug("Link preview caption selected: source=#{source}", kind: :link_preview)
       {:ok, caption}
     end
   end

--- a/lib/save_it/file_helper.ex
+++ b/lib/save_it/file_helper.ex
@@ -97,7 +97,7 @@ defmodule SaveIt.FileHelper do
       :ok ->
         case File.write(Path.join([dir, file_name]), file_content) do
           :ok ->
-            Logger.info("File.write succeeded")
+            Logger.notice("File.write succeeded")
 
           {:error, reason} ->
             Logger.error("File.write failed, reason: #{reason}")

--- a/lib/save_it/file_helper.ex
+++ b/lib/save_it/file_helper.ex
@@ -97,7 +97,7 @@ defmodule SaveIt.FileHelper do
       :ok ->
         case File.write(Path.join([dir, file_name]), file_content) do
           :ok ->
-            Logger.notice("File.write succeeded")
+            :ok
 
           {:error, reason} ->
             Logger.error("File.write failed, reason: #{reason}")

--- a/lib/save_it/photo_service.ex
+++ b/lib/save_it/photo_service.ex
@@ -173,7 +173,7 @@ defmodule SaveIt.PhotoService do
       |> Enum.take(5)
       |> Enum.map(&Map.get(&1, "vector_distance"))
 
-    Logger.info(
+    Logger.debug(
       "Typesense #{action} response: " <>
         "metadata=#{format_log_fields(metadata)} " <>
         "hits_count=#{hits_count} " <>

--- a/lib/save_it/video_upload.ex
+++ b/lib/save_it/video_upload.ex
@@ -12,7 +12,7 @@ defmodule SaveIt.VideoUpload do
         {{:file_content, prepared_content, file_name}, metadata}
 
       {:error, reason} ->
-        Logger.warning("Skipping video faststart preparation: #{inspect(reason)}")
+        Logger.debug("Skipping video faststart preparation: #{inspect(reason)}")
         {{:file_content, file_content, file_name}, probe_file_content(file_content, file_name)}
     end
   end
@@ -25,7 +25,7 @@ defmodule SaveIt.VideoUpload do
         prepare({:file_content, file_content, file_name})
 
       {:error, reason} ->
-        Logger.warning("Skipping video metadata probing: #{inspect(reason)}")
+        Logger.debug("Skipping video metadata probing: #{inspect(reason)}")
         {{:file, file_path}, %{}}
     end
   end
@@ -36,7 +36,7 @@ defmodule SaveIt.VideoUpload do
         metadata
 
       {:error, reason} ->
-        Logger.warning("Skipping video metadata probing: #{inspect(reason)}")
+        Logger.debug("Skipping video metadata probing: #{inspect(reason)}")
         %{}
     end
   end

--- a/lib/small_sdk/hls_downloader.ex
+++ b/lib/small_sdk/hls_downloader.ex
@@ -31,7 +31,7 @@ defmodule SmallSdk.HlsDownloader do
     filename = gen_filename(original_url) <> ".mp4"
     tmp_path = Path.join(System.tmp_dir!(), filename)
 
-    Logger.info("HLS: trying variant #{variant.resolution} (#{variant.bandwidth} bps)")
+    Logger.debug("HLS: trying variant #{variant.resolution} (#{variant.bandwidth} bps)")
 
     args =
       build_ffmpeg_args(variant, tmp_path)

--- a/lib/small_sdk/link_preview.ex
+++ b/lib/small_sdk/link_preview.ex
@@ -158,7 +158,7 @@ defmodule SmallSdk.LinkPreview do
   defp blank_to_nil(value), do: value
 
   defp log_metadata(page_url, metadata) do
-    Logger.info(
+    Logger.debug(
       "Link preview metadata fetched: " <>
         "page_url=#{format_log_url(page_url)} " <>
         "og_title=#{format_log_value(metadata.title)} " <>

--- a/lib/small_sdk/web_downloader.ex
+++ b/lib/small_sdk/web_downloader.ex
@@ -34,6 +34,7 @@ defmodule SmallSdk.WebDownloader do
 
       {:ok, %{status: status, body: body, headers: headers}} when status in 200..209 ->
         filename = parse_filename_for_url(url, headers)
+        Logger.notice("download_file succeeded, url: #{url}")
 
         {:ok,
          %DownloadedFile{

--- a/lib/small_sdk/web_downloader.ex
+++ b/lib/small_sdk/web_downloader.ex
@@ -25,8 +25,6 @@ defmodule SmallSdk.WebDownloader do
 
   # Stream responses are not supported yet.
   def download_file(url) do
-    Logger.info("download_file started, url: #{url}")
-
     case Req.get(url) do
       {:ok, %{status: status, body: ""}} ->
         Logger.warning("Downloaded an empty file, status: #{status}")
@@ -34,7 +32,6 @@ defmodule SmallSdk.WebDownloader do
 
       {:ok, %{status: status, body: body, headers: headers}} when status in 200..209 ->
         filename = parse_filename_for_url(url, headers)
-        Logger.notice("download_file succeeded, url: #{url}")
 
         {:ok,
          %DownloadedFile{

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -166,7 +166,17 @@ defmodule SaveIt.BotTest do
       message_id: 97
     }
 
-    assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+    log =
+      capture_log(fn ->
+        assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+      end)
+
+    refute log =~ "[notice] resource_created"
+    refute log =~ "download_file started"
+    refute log =~ "download_file succeeded"
+    refute log =~ "File.write succeeded"
+    refute log =~ "Link preview metadata fetched"
+    refute log =~ "Link preview caption selected"
 
     assert_receive {:test_http_request, :post, "/", cobalt_body}
     assert Jason.decode!(cobalt_body) == %{"url" => original_url}
@@ -252,7 +262,7 @@ defmodule SaveIt.BotTest do
     assert document["source_message_url"] == "https://t.me/c/1234567890/42/77"
   end
 
-  test "falls back to the x.com URL og title as caption and logs preview metadata",
+  test "falls back to the x.com URL og title as caption without logging preview metadata by default",
        %{base_url: base_url} do
     original_url = "https://x.com/example/status/1?utm_source=telegram"
     preview_url = base_url <> "/x-title-only-page"
@@ -270,10 +280,13 @@ defmodule SaveIt.BotTest do
         assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
       end)
 
-    assert log =~ "Link preview metadata fetched"
-    assert log =~ "og_title=\"X Title Only Page OG Title\""
-    assert log =~ "og_description=nil"
-    assert log =~ "og_image=\"#{base_url}/preview.jpg\""
+    refute log =~ "Link preview metadata fetched"
+    refute log =~ "Link preview caption selected"
+    assert log =~ "[notice] resource_created"
+    assert log =~ "source=url_download"
+    refute log =~ "download_file started"
+    refute log =~ "download_file succeeded"
+    refute log =~ "File.write succeeded"
 
     assert_receive {:test_http_request, :post, "/", cobalt_body}
     assert Jason.decode!(cobalt_body) == %{"url" => "https://x.com/example/status/1"}

--- a/test/logger_config_test.exs
+++ b/test/logger_config_test.exs
@@ -5,13 +5,14 @@ defmodule SaveIt.LoggerConfigTest do
   @test_config Path.expand("../config/test.exs", __DIR__)
   @runtime_config Path.expand("../config/runtime.exs", __DIR__)
 
-  test "runtime logger uses distinct severity colors" do
+  test "runtime logger uses green only for resource creation notices" do
     assert Application.fetch_env!(:logger, :level) == :info
 
     logger_config = Application.fetch_env!(:logger, :default_formatter)
 
     assert logger_config[:metadata] == [:status, :file_id, :kind]
-    assert logger_config[:colors][:info] == :green
+    assert logger_config[:colors][:info] == :normal
+    assert logger_config[:colors][:notice] == :green
     assert logger_config[:colors][:warning] == :yellow
     assert logger_config[:colors][:error] == :red
   end

--- a/test/save_it/file_helper_test.exs
+++ b/test/save_it/file_helper_test.exs
@@ -1,0 +1,45 @@
+defmodule SaveIt.FileHelperTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias SaveIt.FileHelper
+
+  setup do
+    previous_files_dir = Application.get_env(:save_it, :storage_files_dir)
+    previous_urls_dir = Application.get_env(:save_it, :storage_urls_dir)
+
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "save_it_file_helper_test_#{System.unique_integer([:positive])}"
+      )
+
+    files_dir = Path.join(tmp_dir, "files")
+    urls_dir = Path.join(tmp_dir, "urls")
+
+    Application.put_env(:save_it, :storage_files_dir, files_dir)
+    Application.put_env(:save_it, :storage_urls_dir, urls_dir)
+
+    on_exit(fn ->
+      restore_env(:storage_files_dir, previous_files_dir)
+      restore_env(:storage_urls_dir, previous_urls_dir)
+      File.rm_rf!(tmp_dir)
+    end)
+
+    :ok
+  end
+
+  test "logs file writes as resource creation notices" do
+    log =
+      capture_log(fn ->
+        FileHelper.write_file("photo.jpg", "image-bytes", "https://example.com/photo.jpg")
+      end)
+
+    assert log =~ "[notice]"
+    assert log =~ "File.write succeeded"
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:save_it, key)
+  defp restore_env(key, value), do: Application.put_env(:save_it, key, value)
+end

--- a/test/save_it/file_helper_test.exs
+++ b/test/save_it/file_helper_test.exs
@@ -30,14 +30,14 @@ defmodule SaveIt.FileHelperTest do
     :ok
   end
 
-  test "logs file writes as resource creation notices" do
+  test "does not log successful file writes at the default level" do
     log =
       capture_log(fn ->
         FileHelper.write_file("photo.jpg", "image-bytes", "https://example.com/photo.jpg")
       end)
 
-    assert log =~ "[notice]"
-    assert log =~ "File.write succeeded"
+    refute log =~ "[notice]"
+    refute log =~ "File.write succeeded"
   end
 
   defp restore_env(key, nil), do: Application.delete_env(:save_it, key)

--- a/test/small_sdk/web_downloader_test.exs
+++ b/test/small_sdk/web_downloader_test.exs
@@ -1,0 +1,93 @@
+defmodule SmallSdk.WebDownloaderTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias SmallSdk.WebDownloader
+
+  test "logs download start as ordinary info and successful downloads as resource creation notices" do
+    server = start_supervised!({__MODULE__.TestHttpServer, test_pid: self()})
+    port = GenServer.call(server, :port)
+
+    log =
+      capture_log(fn ->
+        assert {:ok, downloaded_file} =
+                 WebDownloader.download_file("http://127.0.0.1:#{port}/photo.jpg")
+
+        assert downloaded_file.file_content == "file-bytes"
+      end)
+
+    assert log =~ "[info] download_file started"
+    assert log =~ "[notice] download_file succeeded"
+  end
+
+  defmodule TestHttpServer do
+    use GenServer
+
+    defstruct [:listen_socket, :port, :acceptor_pid]
+
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl GenServer
+    def init(opts) do
+      {:ok, listen_socket} =
+        :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+      {:ok, port} = :inet.port(listen_socket)
+      test_pid = Keyword.fetch!(opts, :test_pid)
+
+      {:ok, acceptor_pid} =
+        Task.start_link(fn ->
+          accept_loop(listen_socket, test_pid)
+        end)
+
+      {:ok, %__MODULE__{listen_socket: listen_socket, port: port, acceptor_pid: acceptor_pid}}
+    end
+
+    @impl GenServer
+    def handle_call(:port, _from, %{port: port} = state), do: {:reply, port, state}
+
+    @impl GenServer
+    def terminate(_reason, %{listen_socket: listen_socket, acceptor_pid: acceptor_pid}) do
+      if is_pid(acceptor_pid) do
+        Process.exit(acceptor_pid, :normal)
+      end
+
+      :gen_tcp.close(listen_socket)
+      :ok
+    end
+
+    defp accept_loop(listen_socket, test_pid) do
+      case :gen_tcp.accept(listen_socket) do
+        {:ok, socket} ->
+          handle_socket(socket, test_pid)
+          accept_loop(listen_socket, test_pid)
+
+        {:error, :closed} ->
+          :ok
+      end
+    end
+
+    defp handle_socket(socket, test_pid) do
+      {:ok, request} = :gen_tcp.recv(socket, 0, 5_000)
+      [request_line | _] = String.split(request, "\r\n")
+      ["GET", path, _] = String.split(request_line, " ")
+      send(test_pid, {:test_http_request, :get, path})
+      :gen_tcp.send(socket, response())
+      :gen_tcp.close(socket)
+    end
+
+    defp response do
+      body = "file-bytes"
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: image/jpeg\r
+      content-length: #{byte_size(body)}\r
+      connection: close\r
+      \r
+      #{body}
+      """
+    end
+  end
+end

--- a/test/small_sdk/web_downloader_test.exs
+++ b/test/small_sdk/web_downloader_test.exs
@@ -5,7 +5,7 @@ defmodule SmallSdk.WebDownloaderTest do
 
   alias SmallSdk.WebDownloader
 
-  test "logs download start as ordinary info and successful downloads as resource creation notices" do
+  test "does not log successful downloads at the default level" do
     server = start_supervised!({__MODULE__.TestHttpServer, test_pid: self()})
     port = GenServer.call(server, :port)
 
@@ -17,8 +17,8 @@ defmodule SmallSdk.WebDownloaderTest do
         assert downloaded_file.file_content == "file-bytes"
       end)
 
-    assert log =~ "[info] download_file started"
-    assert log =~ "[notice] download_file succeeded"
+    refute log =~ "download_file started"
+    refute log =~ "download_file succeeded"
   end
 
   defmodule TestHttpServer do


### PR DESCRIPTION
## Summary

- Keep ordinary `info` logs uncolored and reserve green output for `notice` logs.
- Redesign default runtime logging so successful intermediate steps stay quiet or move to `debug`.
- Emit a single `resource_created` notice from the bot layer after URL downloads are fully saved.
- Keep recoverable fallbacks as warnings and required-operation failures as errors.
- Add regression coverage for logger color configuration and reduced success-path log noise.

## Impact

`/goal log` and runtime logs should now read more like an event stream instead of a step-by-step trace. Routine details such as download start/success, local file-write success, link preview metadata success, caption source selection, Typesense search response summaries, HLS variant attempts, and optional video probing are no longer shown at the default log level.

Green logs are reserved for resource creation events such as `resource_created source=url_download ...`.

## Conflict resolution

- Merged the latest `main` into `fix/log-resource-create-colors` because GitHub reported the PR as `DIRTY`.
- Resolved the `CHANGELOG.md` conflict by preserving both the base branch changelog entries and this PR's log entries.

## Validation

- `mix format --check-formatted`
- `mix test test/logger_config_test.exs test/small_sdk/web_downloader_test.exs test/save_it/file_helper_test.exs test/bot_test.exs test/small_sdk/link_preview_test.exs test/save_it/photo_service_test.exs`
- `mix test`
- `git diff --check`
