### PR TITLE
feat: show chat status in about command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Added
+
+- Show chat type, public visibility, bot admin status, and bot Privacy Mode status in the `/about` command.
+
 ### Fixed
 
 - Fix Zeabur Cobalt cookie setup to use a file config at `/cookies.json` instead of mounting a volume as a file.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -59,9 +59,16 @@ defmodule SaveIt.Bot do
     answer(context, "Hi! I'm a bot that can download images and videos, just give me a link.")
   end
 
-  def handle({:command, :about, _msg}, context) do
-    answer(context, """
+  def handle({:command, :about, %{chat: chat}}, _context) do
+    bot_info = about_bot_info()
+
+    send_message(chat.id, """
     SaveIt can download images and videos, just give me a link.
+
+    Chat: #{about_chat_type(chat)}
+    Public: #{about_public_status(chat)}
+    Bot admin: #{about_bot_admin_status(chat, bot_info)}
+    Privacy Mode: #{about_privacy_mode_status(bot_info)}
 
     Created by @ThaddeusJiang, powered by Cobalt, Typesense, and Elixir.Access
 
@@ -822,6 +829,49 @@ defmodule SaveIt.Bot do
   defp send_message(chat_id, text) do
     ExGram.send_message(chat_id, text)
   end
+
+  defp about_chat_type(%{type: "private"}), do: "dm"
+  defp about_chat_type(%{type: "group"}), do: "group"
+  defp about_chat_type(%{type: "supergroup"}), do: "group"
+  defp about_chat_type(%{type: "channel"}), do: "channel"
+  defp about_chat_type(%{type: type}) when is_binary(type), do: type
+  defp about_chat_type(_chat), do: "unknown"
+
+  defp about_public_status(%{username: username}) when is_binary(username) do
+    if String.trim(username) == "", do: "no", else: "yes"
+  end
+
+  defp about_public_status(_chat), do: "no"
+
+  defp about_bot_info, do: ExGram.get_me()
+
+  defp about_bot_admin_status(%{type: "private"}, _bot_info), do: "n/a"
+
+  defp about_bot_admin_status(%{id: chat_id}, bot_info) do
+    case about_bot_id(bot_info) do
+      nil ->
+        "unknown"
+
+      bot_id ->
+        case ExGram.get_chat_member(chat_id, bot_id) do
+          {:ok, %{status: status}} when status in ["administrator", "creator", "owner"] -> "yes"
+          {:ok, %{status: _status}} -> "no"
+          {:error, _reason} -> "unknown"
+        end
+    end
+  end
+
+  defp about_bot_admin_status(_chat, _bot_info), do: "unknown"
+
+  defp about_bot_id({:ok, %{id: bot_id}}), do: bot_id
+  defp about_bot_id(%{id: bot_id}), do: bot_id
+  defp about_bot_id(_bot_info), do: nil
+
+  defp about_privacy_mode_status({:ok, %{can_read_all_group_messages: true}}), do: "disabled"
+  defp about_privacy_mode_status({:ok, %{can_read_all_group_messages: false}}), do: "enabled"
+  defp about_privacy_mode_status(%{can_read_all_group_messages: true}), do: "disabled"
+  defp about_privacy_mode_status(%{can_read_all_group_messages: false}), do: "enabled"
+  defp about_privacy_mode_status(_bot_info), do: "unknown"
 
   defp update_message(chat_id, message_id, texts) when is_list(texts) do
     ExGram.edit_message_text(Enum.join(texts, "\n"), chat_id: chat_id, message_id: message_id)

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -63,6 +63,85 @@ defmodule SaveIt.BotTest do
     %{base_url: base_url}
   end
 
+  test "about reports private chat status and bot privacy mode", _context do
+    ExGramTestAdapter.backdoor_request(:get_me, %{
+      id: 9_001,
+      username: "save_it_bot",
+      can_read_all_group_messages: false
+    })
+
+    message = %{
+      chat: %{id: 12_345, type: "private"},
+      message_id: 11
+    }
+
+    assert {:ok, %{message_id: 10}} = Bot.handle({:command, :about, message}, nil)
+
+    request_body = sent_message_body()
+
+    assert request_body.chat_id == 12_345
+    assert request_body.text =~ "Chat: dm"
+    assert request_body.text =~ "Public: no"
+    assert request_body.text =~ "Bot admin: n/a"
+    assert request_body.text =~ "Privacy Mode: enabled"
+  end
+
+  test "about reports public group status and bot admin membership", _context do
+    ExGramTestAdapter.backdoor_request(:get_me, %{
+      id: 9_001,
+      username: "save_it_bot",
+      can_read_all_group_messages: true
+    })
+
+    ExGramTestAdapter.backdoor_request(:get_chat_member, fn body ->
+      assert body == %{chat_id: -100_123, user_id: 9_001}
+      %{status: "administrator", user: %{id: 9_001, is_bot: true}}
+    end)
+
+    message = %{
+      chat: %{id: -100_123, type: "supergroup", username: "save_it_group"},
+      message_id: 12
+    }
+
+    assert {:ok, %{message_id: 10}} = Bot.handle({:command, :about, message}, nil)
+
+    request_body = sent_message_body()
+
+    assert request_body.chat_id == -100_123
+    assert request_body.text =~ "Chat: group"
+    assert request_body.text =~ "Public: yes"
+    assert request_body.text =~ "Bot admin: yes"
+    assert request_body.text =~ "Privacy Mode: disabled"
+  end
+
+  test "about reports private channel status and non-admin membership", _context do
+    ExGramTestAdapter.backdoor_request(:get_me, %{
+      id: 9_001,
+      username: "save_it_bot",
+      can_read_all_group_messages: false
+    })
+
+    ExGramTestAdapter.backdoor_request(:get_chat_member, fn body ->
+      assert body == %{chat_id: -100_456, user_id: 9_001}
+      %{status: "member", user: %{id: 9_001, is_bot: true}}
+    end)
+
+    message = %{
+      chat: %{id: -100_456, type: "channel"},
+      message_id: 13
+    }
+
+    assert {:ok, %{message_id: 10}} = Bot.handle({:command, :about, message}, nil)
+
+    request_body = sent_message_body()
+
+    assert request_body.chat_id == -100_456
+    assert request_body.text =~ "Chat: channel"
+    assert request_body.text =~ "Public: no"
+    assert request_body.text =~ "Bot admin: no"
+    assert request_body.text =~ "Privacy Mode: enabled"
+  end
+
   test "uses user text as the caption when indexing a downloaded URL photo", %{base_url: base_url} do
     original_url = "https://x.com/example/status/1?utm_source=telegram"
     message_text = "summer reference #{original_url}"


### PR DESCRIPTION
## Summary

- Extend `/about` to show the current chat surface (`dm`, `group`, or `channel`) and whether the chat is public.
- Report whether the bot is an admin in the current chat when applicable.
- Report the bot Privacy Mode status from Telegram `getMe.can_read_all_group_messages`.
- Add focused bot tests for private DM, public supergroup, and private channel cases.
- Merge latest `main` and resolve the `CHANGELOG.md` conflict by preserving both Unreleased entries.

## Validation

- `mix test test/bot_test.exs --trace`
- `mix format lib/save_it/bot.ex test/bot_test.exs`
- `git diff --check`
- `rg -n '<<<<<<<|=======|>>>>>>>'`
