### PR TITLE
fix: preserve Telegram video preview aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve URL video preview aspect ratios by sending accurate display dimensions and square-pixel Telegram covers/thumbnails.
+
 ## [2026.6.15] - 2026-06-15
 
 ### Added

--- a/docs/postmortem/2026-06-15-telegram-video-thumbnail-aspect-ratio.md
+++ b/docs/postmortem/2026-06-15-telegram-video-thumbnail-aspect-ratio.md
@@ -1,0 +1,17 @@
+# Telegram Video Thumbnail Aspect Ratio
+
+## What happened
+
+URL-downloaded videos were sent back to Telegram with explicit video dimensions, but the visible Telegram preview could still use a different aspect ratio from the actual video.
+
+## Root cause
+
+The video metadata probe read encoded `width` and `height`, plus rotation metadata, but it ignored `display_aspect_ratio` and `sample_aspect_ratio`. Videos with non-square pixels can have display dimensions that differ from their encoded pixel dimensions. The bot therefore passed dimensions to Telegram that were still not the true display ratio, so Telegram's own video preview frame could be shaped differently from the actual video.
+
+## Fix applied
+
+The metadata probe now requests `sample_aspect_ratio` and `display_aspect_ratio` from `ffprobe`. It derives display dimensions from that aspect ratio first, then applies rotation, and passes the resulting `width` and `height` to Telegram `sendVideo`. The bot also generates a square-pixel JPEG whose pixel ratio matches those display dimensions and uploads it as both Telegram `cover` and `thumbnail`. That generated image is used for Telegram's visible message cover and for Typesense preview indexing without storing an unrelated webpage `thumbnail_url`. If cover generation fails, the bot falls back to Telegram's returned video thumbnail, then to the webpage preview image.
+
+## What we learned
+
+Telegram can generate video thumbnails itself, but that server-generated thumbnail can be ignored or shaped differently from the display ratio. The visible message cover still needs accurate display dimensions and square-pixel preview pixels. Encoded pixels, sample aspect ratio, display aspect ratio, and rotation all need to be considered before deciding which `width` and `height` to send to Telegram and which JPEG preview dimensions to generate.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -1291,11 +1291,12 @@ defmodule SaveIt.Bot do
 
       ".mp4" ->
         {prepared_content, video_metadata} = VideoUpload.prepare(content)
+        video_cover = VideoUpload.cover(prepared_content, video_metadata)
 
         case ExGram.send_video(
                chat_id,
                prepared_content,
-               video_send_opts(caption, video_metadata, message_thread_id)
+               video_send_opts(caption, video_metadata, video_cover, message_thread_id)
              ) do
           {:ok, msg} = response ->
             index_sent_video_preview(chat_id, msg,
@@ -1303,7 +1304,8 @@ defmodule SaveIt.Bot do
               source_url: source_url,
               download_url: download_url,
               thumbnail_url: thumbnail_url,
-              source_chat: source_chat
+              source_chat: source_chat,
+              video_cover: video_cover
             )
 
             response
@@ -1325,11 +1327,12 @@ defmodule SaveIt.Bot do
     |> put_optional_keyword(:message_thread_id, message_thread_id)
   end
 
-  defp video_send_opts(caption, video_metadata, message_thread_id) do
+  defp video_send_opts(caption, video_metadata, video_cover, message_thread_id) do
     [supports_streaming: true, caption: caption]
     |> maybe_put_video_metadata(:width, video_metadata)
     |> maybe_put_video_metadata(:height, video_metadata)
     |> maybe_put_video_metadata(:duration, video_metadata)
+    |> maybe_put_video_preview_files(video_cover)
     |> put_optional_keyword(:message_thread_id, message_thread_id)
   end
 
@@ -1340,16 +1343,32 @@ defmodule SaveIt.Bot do
     end
   end
 
+  defp maybe_put_video_preview_files(
+         opts,
+         {:ok, %{file_content: file_content, file_name: file_name}}
+       )
+       when is_binary(file_content) and is_binary(file_name) do
+    opts
+    |> Keyword.put(:cover, {:file_content, file_content, file_name})
+    |> Keyword.put(:thumbnail, {:file_content, file_content, file_name})
+  end
+
+  defp maybe_put_video_preview_files(opts, _video_cover), do: opts
+
   defp index_sent_video_preview(chat_id, msg, opts) do
     caption = Keyword.fetch!(opts, :caption)
     source_url = Keyword.get(opts, :source_url)
     download_url = Keyword.get(opts, :download_url)
     thumbnail_url = Keyword.get(opts, :thumbnail_url)
     source_chat = Keyword.fetch!(opts, :source_chat)
+    video_cover = Keyword.get(opts, :video_cover)
+
+    indexed_thumbnail_url =
+      if match?({:ok, _cover}, video_cover), do: nil, else: thumbnail_url
 
     with file_id when is_binary(file_id) <- sent_video_file_id(msg),
          {:ok, %DownloadedFile{} = file} <-
-           download_sent_video_preview(msg, source_url, thumbnail_url) do
+           download_sent_video_preview(msg, source_url, thumbnail_url, video_cover) do
       %{
         image: Base.encode64(file.file_content),
         caption: caption,
@@ -1359,7 +1378,7 @@ defmodule SaveIt.Bot do
         belongs_to_id: chat_id
       }
       |> put_optional(:download_url, download_url)
-      |> put_optional(:thumbnail_url, thumbnail_url)
+      |> put_optional(:thumbnail_url, indexed_thumbnail_url)
       |> Map.merge(source_message_fields(source_chat, msg))
       |> safe_index_photo()
 
@@ -1375,7 +1394,15 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp download_sent_video_preview(msg, source_url, thumbnail_url) do
+  defp download_sent_video_preview(_msg, _source_url, _thumbnail_url, {:ok, video_cover}) do
+    {:ok,
+     %DownloadedFile{
+       file_name: video_cover.file_name,
+       file_content: video_cover.file_content
+     }}
+  end
+
+  defp download_sent_video_preview(msg, source_url, thumbnail_url, _video_cover) do
     case download_message_thumbnail(msg) do
       {:ok, %DownloadedFile{} = file} -> {:ok, file}
       {:error, _reason} -> download_preview_image(thumbnail_url, source_url)

--- a/lib/save_it/video_metadata.ex
+++ b/lib/save_it/video_metadata.ex
@@ -14,7 +14,7 @@ defmodule SaveIt.VideoMetadata do
       "-select_streams",
       "v:0",
       "-show_entries",
-      "stream=width,height,duration:stream_tags=rotate:side_data=rotation:format=duration",
+      "stream=width,height,duration,sample_aspect_ratio,display_aspect_ratio:stream_tags=rotate:stream_side_data=rotation:format=duration",
       "-of",
       "json",
       file_path
@@ -22,7 +22,7 @@ defmodule SaveIt.VideoMetadata do
 
     case System.cmd("ffprobe", args, stderr_to_stdout: true) do
       {json, 0} ->
-        decode_metadata(json)
+        decode_ffprobe_json(json)
 
       {output, exit_code} ->
         {:error, {:ffprobe_failed, exit_code, output}}
@@ -32,7 +32,7 @@ defmodule SaveIt.VideoMetadata do
       {:error, {:ffprobe_unavailable, error}}
   end
 
-  defp decode_metadata(json) do
+  def decode_ffprobe_json(json) do
     with {:ok, decoded} <- Jason.decode(json),
          %{} = stream <- decoded |> Map.get("streams", []) |> List.first(),
          {:ok, width} <- positive_integer(stream["width"]),
@@ -42,7 +42,9 @@ defmodule SaveIt.VideoMetadata do
           get_in(decoded, ["format", "duration"])
 
       {display_width, display_height} =
-        display_dimensions(width, height, rotation(stream))
+        stream
+        |> display_dimensions(width, height)
+        |> rotate_dimensions(rotation(stream))
 
       metadata =
         %{
@@ -63,10 +65,16 @@ defmodule SaveIt.VideoMetadata do
     end
   end
 
-  defp display_dimensions(width, height, rotation) when rotation in [90, 270, -90, -270],
+  defp display_dimensions(stream, width, height) do
+    ratio_dimensions(width, height, stream["display_aspect_ratio"]) ||
+      sample_aspect_dimensions(width, height, stream["sample_aspect_ratio"]) ||
+      {width, height}
+  end
+
+  defp rotate_dimensions({width, height}, rotation) when rotation in [90, 270, -90, -270],
     do: {height, width}
 
-  defp display_dimensions(width, height, _rotation), do: {width, height}
+  defp rotate_dimensions({width, height}, _rotation), do: {width, height}
 
   defp rotation(stream) do
     [
@@ -94,6 +102,22 @@ defmodule SaveIt.VideoMetadata do
     end
   end
 
+  defp ratio_dimensions(_width, height, ratio) do
+    with {:ok, numerator, denominator} <- positive_ratio(ratio) do
+      {round(height * numerator / denominator), height}
+    else
+      _ -> nil
+    end
+  end
+
+  defp sample_aspect_dimensions(width, height, ratio) do
+    with {:ok, numerator, denominator} <- positive_ratio(ratio) do
+      {round(width * numerator / denominator), height}
+    else
+      _ -> nil
+    end
+  end
+
   defp positive_integer(value) when is_integer(value) and value > 0, do: {:ok, value}
 
   defp positive_integer(value) do
@@ -112,6 +136,21 @@ defmodule SaveIt.VideoMetadata do
       :error -> nil
     end
   end
+
+  defp positive_ratio(value) when is_binary(value) do
+    case String.split(value, ":", parts: 2) do
+      [numerator, denominator] ->
+        with {:ok, numerator} <- positive_integer(numerator),
+             {:ok, denominator} <- positive_integer(denominator) do
+          {:ok, numerator, denominator}
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp positive_ratio(_value), do: :error
 
   defp with_temp_file(file_name, file_content, fun) do
     tmp_dir =

--- a/lib/save_it/video_upload.ex
+++ b/lib/save_it/video_upload.ex
@@ -5,6 +5,8 @@ defmodule SaveIt.VideoUpload do
 
   alias SaveIt.VideoMetadata
 
+  @telegram_cover_max_dimension 320
+
   def prepare({:file_content, file_content, file_name})
       when is_binary(file_content) and is_binary(file_name) do
     case preparer().prepare_file_content(file_content, file_name) do
@@ -30,6 +32,34 @@ defmodule SaveIt.VideoUpload do
     end
   end
 
+  def cover({:file_content, file_content, file_name}, metadata)
+      when is_binary(file_content) and is_binary(file_name) and is_map(metadata) do
+    with {:ok, dimensions} <- cover_dimensions(metadata),
+         {:ok, cover_content} <-
+           cover_generator().cover_file_content(file_content, file_name, dimensions) do
+      {:ok,
+       %{
+         file_content: cover_content,
+         file_name: cover_file_name(file_name)
+       }}
+    else
+      {:error, reason} ->
+        Logger.debug("Skipping video cover upload: #{inspect(reason)}")
+        :error
+    end
+  end
+
+  def cover({:file, file_path}, metadata) when is_binary(file_path) and is_map(metadata) do
+    case File.read(file_path) do
+      {:ok, file_content} ->
+        cover({:file_content, file_content, Path.basename(file_path)}, metadata)
+
+      {:error, reason} ->
+        Logger.debug("Skipping video cover upload: #{inspect(reason)}")
+        :error
+    end
+  end
+
   defp probe_file_content(file_content, file_name) do
     case metadata_probe().probe_file_content(file_content, file_name) do
       {:ok, metadata} ->
@@ -47,6 +77,30 @@ defmodule SaveIt.VideoUpload do
 
   defp metadata_probe do
     Application.get_env(:save_it, :video_metadata_probe, VideoMetadata)
+  end
+
+  defp cover_generator do
+    Application.get_env(:save_it, :video_cover_generator, __MODULE__.FFmpegCover)
+  end
+
+  defp cover_dimensions(%{width: width, height: height})
+       when is_integer(width) and width > 0 and is_integer(height) and height > 0 do
+    scale = @telegram_cover_max_dimension / max(width, height)
+
+    {:ok,
+     %{
+       width: max(1, round(width * scale)),
+       height: max(1, round(height * scale))
+     }}
+  end
+
+  defp cover_dimensions(_metadata), do: {:error, :missing_video_display_dimensions}
+
+  defp cover_file_name(file_name) do
+    file_name
+    |> Path.basename()
+    |> Path.rootname()
+    |> Kernel.<>("-cover.jpg")
   end
 
   defmodule FFmpegFaststart do
@@ -103,6 +157,62 @@ defmodule SaveIt.VideoUpload do
 
       input_path = Path.join(tmp_dir, "input#{Path.extname(file_name)}")
       output_path = Path.join(tmp_dir, file_name)
+
+      try do
+        File.mkdir_p!(tmp_dir)
+        File.write!(input_path, file_content)
+        fun.(input_path, output_path)
+      after
+        File.rm_rf(tmp_dir)
+      end
+    end
+  end
+
+  defmodule FFmpegCover do
+    @moduledoc false
+
+    def cover_file_content(file_content, file_name, %{width: width, height: height})
+        when is_binary(file_content) and is_binary(file_name) and is_integer(width) and
+               is_integer(height) do
+      with_temp_files(file_name, file_content, fn input_path, output_path ->
+        args = [
+          "-y",
+          "-i",
+          input_path,
+          "-an",
+          "-frames:v",
+          "1",
+          "-vf",
+          "thumbnail,scale=#{width}:#{height},setsar=1",
+          "-q:v",
+          "5",
+          "-loglevel",
+          "warning",
+          output_path
+        ]
+
+        with {_output, 0} <- System.cmd("ffmpeg", args, stderr_to_stdout: true),
+             {:ok, cover_content} <- File.read(output_path) do
+          {:ok, cover_content}
+        else
+          {output, exit_code} when is_integer(exit_code) ->
+            {:error, {:ffmpeg_cover_failed, exit_code, output}}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+      end)
+    rescue
+      error in ErlangError ->
+        {:error, {:ffmpeg_unavailable, error}}
+    end
+
+    defp with_temp_files(file_name, file_content, fun) do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "save-it-video-cover-#{System.unique_integer([:positive])}")
+
+      input_path = Path.join(tmp_dir, "input#{Path.extname(file_name)}")
+      output_path = Path.join(tmp_dir, "cover.jpg")
 
       try do
         File.mkdir_p!(tmp_dir)

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -562,7 +562,7 @@ defmodule SaveIt.BotTest do
            end)
   end
 
-  test "indexes a downloaded URL video using the Telegram video thumbnail before the webpage preview",
+  test "indexes a downloaded URL video using a generated cover before Telegram and webpage previews",
        %{base_url: base_url} do
     original_url = base_url <> "/video-page-with-telegram-thumbnail"
     download_url = base_url <> "/downloaded/video.mp4"
@@ -575,6 +575,7 @@ defmodule SaveIt.BotTest do
     )
 
     Application.put_env(:save_it, :video_metadata_probe, __MODULE__.VideoMetadataProbe)
+    Application.put_env(:save_it, :video_cover_generator, __MODULE__.VideoCoverGenerator)
 
     message = %{
       chat: %{id: 12_345, username: "save_it_test_chat"},
@@ -598,6 +599,66 @@ defmodule SaveIt.BotTest do
     assert multipart_part(parts, "width") == "1080"
     assert multipart_part(parts, "height") == "1920"
     assert multipart_part(parts, "duration") == "12"
+    assert multipart_part(parts, "thumbnail") == :file_content
+    assert multipart_file_content(parts, "thumbnail") == test_video_cover()
+    assert multipart_part(parts, "cover") == :file_content
+    assert multipart_file_content(parts, "cover") == test_video_cover()
+
+    refute_receive {:telegram_download_request, _telegram_env}
+
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    refute Map.has_key?(document, "thumbnail_url")
+    assert document["caption"] == "clip notes"
+    assert document["file_id"] == "sent-video-file-id"
+    assert document["media_type"] == "video"
+    assert document["image"] == Base.encode64(test_video_cover())
+    refute Map.has_key?(document, "source_message_id")
+    assert document["source_message_url"] == "https://t.me/save_it_test_chat/70"
+
+    assert_receive {:test_http_request, :get, "/video-page-with-telegram-thumbnail", ""}
+    refute_receive {:test_http_request, :get, "/video-preview.jpg", ""}
+    refute_receive {:test_http_request, :get, "/preview.jpg", ""}
+
+    assert File.exists?(storage_file_path(cached_video_name(base_url)))
+
+    assert File.read(storage_file_path(cached_video_cover_name(base_url))) ==
+             {:ok, test_video_cover()}
+  end
+
+  test "falls back to the Telegram video thumbnail when generated cover is unavailable",
+       %{base_url: base_url} do
+    original_url = base_url <> "/video-page-with-telegram-thumbnail"
+    download_url = base_url <> "/downloaded/video.mp4"
+
+    Application.put_env(:ex_gram, :adapter, __MODULE__.UrlVideoThumbnailAdapter)
+
+    Application.put_env(:save_it, :telegram_req_options,
+      adapter: &__MODULE__.TelegramDownloadAdapter.request/1
+    )
+
+    Application.put_env(:save_it, :video_metadata_probe, __MODULE__.VideoMetadataProbe)
+    Application.put_env(:save_it, :video_cover_generator, __MODULE__.FailingVideoCoverGenerator)
+
+    message = %{
+      chat: %{id: 12_345, username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 104,
+      text: original_url,
+      link_preview_options: %{url: original_url}
+    }
+
+    assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+
+    assert_receive {:test_http_request, :get, "/downloaded/video.mp4", ""}
+    assert_receive {:exgram_request, :post, "/bottest-token/sendVideo", {:multipart, parts}}
+
+    refute multipart_part(parts, "thumbnail")
+    refute multipart_part(parts, "cover")
 
     assert_receive {:telegram_download_request, telegram_env}
 
@@ -612,20 +673,9 @@ defmodule SaveIt.BotTest do
     assert document["url"] == original_url
     assert document["download_url"] == download_url
     assert document["thumbnail_url"] == base_url <> "/video-preview.jpg"
-    assert document["caption"] == "clip notes"
     assert document["file_id"] == "sent-video-file-id"
     assert document["media_type"] == "video"
     assert document["image"] == Base.encode64(test_jpeg())
-    refute Map.has_key?(document, "source_message_id")
-    assert document["source_message_url"] == "https://t.me/save_it_test_chat/70"
-
-    assert_receive {:test_http_request, :get, "/video-page-with-telegram-thumbnail", ""}
-    refute_receive {:test_http_request, :get, "/video-preview.jpg", ""}
-    refute_receive {:test_http_request, :get, "/preview.jpg", ""}
-
-    assert File.exists?(storage_file_path(cached_video_name(base_url)))
-
-    assert File.read(storage_file_path("sent.jpg")) == {:ok, test_jpeg()}
   end
 
   test "indexes a downloaded video using the webpage preview when Telegram has no thumbnail", %{
@@ -1459,6 +1509,12 @@ defmodule SaveIt.BotTest do
     |> then(&(&1 <> ".jpeg"))
   end
 
+  defp cached_video_cover_name(base_url) do
+    base_url
+    |> cached_video_name()
+    |> String.replace_suffix(".mp4", "-cover.jpg")
+  end
+
   defp storage_file_path(file_name), do: Path.join(FileHelper.files_dir(), file_name)
   defp storage_url_path(file_name), do: Path.join(FileHelper.urls_dir(), file_name)
 
@@ -1515,6 +1571,10 @@ defmodule SaveIt.BotTest do
     <<255, 216, 255, 224, 0, 16, 79, 71, 73, 70>>
   end
 
+  def test_video_cover do
+    <<255, 216, 255, 224, 0, 16, 67, 79, 86, 69, 82>>
+  end
+
   def test_mp4 do
     <<0, 0, 0, 24, 102, 116, 121, 112, 109, 112, 52, 50>>
   end
@@ -1540,6 +1600,13 @@ defmodule SaveIt.BotTest do
     Enum.find_value(parts, fn
       {^name, value} -> value
       {_file_content, ^name, _content, _file_name} -> :file_content
+      _part -> nil
+    end)
+  end
+
+  defp multipart_file_content(parts, name) when is_list(parts) do
+    Enum.find_value(parts, fn
+      {:file_content, ^name, content, _file_name} -> content
       _part -> nil
     end)
   end
@@ -1735,6 +1802,20 @@ defmodule SaveIt.BotTest do
     end
 
     def probe_file(_file_path), do: {:error, :unexpected_probe_file}
+  end
+
+  defmodule VideoCoverGenerator do
+    def cover_file_content(_file_content, file_name, %{width: 180, height: 320})
+        when is_binary(file_name) do
+      {:ok, SaveIt.BotTest.test_video_cover()}
+    end
+  end
+
+  defmodule FailingVideoCoverGenerator do
+    def cover_file_content(_file_content, file_name, %{width: 180, height: 320})
+        when is_binary(file_name) do
+      {:error, :cover_unavailable}
+    end
   end
 
   defmodule TelegramDirectMediaAdapter do

--- a/test/save_it/video_metadata_test.exs
+++ b/test/save_it/video_metadata_test.exs
@@ -1,0 +1,58 @@
+defmodule SaveIt.VideoMetadataTest do
+  use ExUnit.Case, async: true
+
+  alias SaveIt.VideoMetadata
+
+  test "uses display aspect ratio for non-square pixel videos" do
+    assert {:ok, metadata} =
+             VideoMetadata.decode_ffprobe_json("""
+             {
+               "streams": [
+                 {
+                   "width": 320,
+                   "height": 180,
+                   "sample_aspect_ratio": "2:1",
+                   "display_aspect_ratio": "32:9",
+                   "duration": "1.000000"
+                 }
+               ],
+               "format": {
+                 "duration": "1.000000"
+               }
+             }
+             """)
+
+    assert metadata.width == 640
+    assert metadata.height == 180
+    assert metadata.duration == 1
+  end
+
+  test "applies rotation after display aspect ratio" do
+    assert {:ok, metadata} =
+             VideoMetadata.decode_ffprobe_json("""
+             {
+               "streams": [
+                 {
+                   "width": 320,
+                   "height": 180,
+                   "sample_aspect_ratio": "2:1",
+                   "display_aspect_ratio": "32:9",
+                   "duration": "1.000000",
+                   "side_data_list": [
+                     {
+                       "rotation": 90
+                     }
+                   ]
+                 }
+               ],
+               "format": {
+                 "duration": "1.000000"
+               }
+             }
+             """)
+
+    assert metadata.width == 180
+    assert metadata.height == 640
+    assert metadata.duration == 1
+  end
+end

--- a/test/save_it/video_upload_test.exs
+++ b/test/save_it/video_upload_test.exs
@@ -1,0 +1,47 @@
+defmodule SaveIt.VideoUploadTest do
+  use ExUnit.Case, async: false
+
+  alias SaveIt.VideoUpload
+
+  setup do
+    previous_save_it = Application.get_all_env(:save_it)
+
+    on_exit(fn ->
+      restore_env(:save_it, previous_save_it)
+    end)
+
+    :ok
+  end
+
+  test "generates square-pixel cover using the video display ratio" do
+    Application.put_env(:save_it, :video_cover_generator, __MODULE__.CoverGenerator)
+
+    assert {:ok, cover} =
+             VideoUpload.cover({:file_content, "video-bytes", "clip.mp4"}, %{
+               width: 180,
+               height: 640
+             })
+
+    assert cover.file_content == "cover-bytes"
+    assert cover.file_name == "clip-cover.jpg"
+    assert_received {:cover_dimensions, %{width: 90, height: 320}}
+  end
+
+  defmodule CoverGenerator do
+    def cover_file_content(_file_content, _file_name, dimensions) do
+      send(self(), {:cover_dimensions, dimensions})
+      {:ok, "cover-bytes"}
+    end
+  end
+
+  defp restore_env(app, previous_env) do
+    app
+    |> Application.get_all_env()
+    |> Keyword.keys()
+    |> Enum.each(&Application.delete_env(app, &1))
+
+    Enum.each(previous_env, fn {key, value} ->
+      Application.put_env(app, key, value)
+    end)
+  end
+end


### PR DESCRIPTION
## Summary

- derive video display dimensions from `display_aspect_ratio` / `sample_aspect_ratio` before applying rotation
- generate a square-pixel JPEG preview at Telegram thumbnail size and upload it as both `cover` and `thumbnail` in `sendVideo`
- use the generated preview for Typesense indexing, with fallback to Telegram-returned video thumbnails and then webpage previews

## Root Cause

The bot previously sent encoded video dimensions to Telegram. For videos with non-square pixels, the encoded dimensions can differ from the actual display ratio, so Telegram's visible preview could be shaped differently from the video.

## Validation

- `mix test`
- `mix format --check-formatted`
- `git diff --check`
- local ffmpeg sample: vertical video generated `90x320`, SAR `1:1`, DAR `9:32`
- local ffmpeg sample: non-square-pixel video generated `320x90`, SAR `1:1`, DAR `32:9`

## Remaining Manual Check

This has not yet been visually confirmed in a real Telegram client with the original issue video because the local environment has `TELEGRAM_BOT_TOKEN` but no target chat id.

Refs #89
