### PR TITLE
fix: simplify resource creation logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ before the CalVer migration retain their original version labels.
 
 ### Fixed
 
+- Render successful resource creation info logs in green in runtime logger output.
 - Use random UUIDv7 filenames for downloaded resources while preserving the original file extension.
 - Preserve URL video preview aspect ratios by sending accurate display dimensions and square-pixel Telegram covers/thumbnails.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,6 @@ config :logger, :default_formatter,
     enabled: true,
     debug: :cyan,
     info: :normal,
-    notice: :green,
     warning: :yellow,
     error: :red
   ]

--- a/docs/adr/0006-keep-runtime-logs-inline-and-simple.md
+++ b/docs/adr/0006-keep-runtime-logs-inline-and-simple.md
@@ -1,0 +1,27 @@
+# Keep Runtime Logs Inline and Simple
+
+## Context and Problem Statement
+
+`save_it` uses runtime logs mostly for local operation, deployment diagnosis, and lightweight visibility into important events. Recent resource creation logging introduced a private helper and extra `kind` metadata around a short success message.
+
+That abstraction made a simple log event harder to read and maintain. The question is how much structure runtime logs should carry before the project has a concrete need for routing, dashboards, or automated log processing.
+
+## Considered Options
+
+* Keep dedicated helper functions for repeated log events
+* Keep log calls inline and include only useful message fields
+* Introduce a custom logging abstraction for structured events
+
+## Decision Outcome
+
+Chosen option: "Keep log calls inline and include only useful message fields", because it keeps runtime output easy to read, avoids log-only indirection, and matches the project's bias toward controlled complexity.
+
+Do not extract helper functions only to wrap `Logger` calls. Do not add metadata such as `kind` unless it is needed by an actual filtering, routing, or operational workflow.
+
+### Consequences
+
+* Good, because logs stay close to the workflow that emits them.
+* Good, because simple events such as `resource_created source=url_download file_name=...` remain easy to scan in terminals and deployment logs.
+* Good, because the project avoids custom logging layers before there is a concrete operational need.
+* Bad, because repeated log message fields may appear in multiple call sites.
+* Bad, because adding structured log filtering later may require revisiting existing inline log calls.

--- a/docs/postmortem/2026-06-16-resource-creation-logger-color.md
+++ b/docs/postmortem/2026-06-16-resource-creation-logger-color.md
@@ -1,0 +1,23 @@
+# Resource Creation Logger Color
+
+## What happened
+
+Resource creation logs were intended to be easy to spot in runtime output by rendering green. The first change configured `notice: :green` in the logger formatter and emitted `Logger.notice`, but actual output stayed uncolored because Elixir's formatter does not support a separate `notice` color key.
+
+The follow-up fix made the output green, but it also introduced private helper functions and `kind: :resource` metadata around a simple success log. That made a short operational message more complex than the project needs.
+
+## Root cause
+
+The implementation assumed that `Logger.Formatter` can color `:notice` independently from `:info`. In Elixir 1.19, notice logs use the configured info color unless the individual log event passes `ansi_color` metadata.
+
+The logging shape also drifted toward abstraction before there was a concrete filtering, routing, or dashboard workflow that needed the helper or extra metadata.
+
+## Fix applied
+
+Resource creation logs now use `Logger.info` with per-event `ansi_color: :green`. The logs are inline at the call sites and contain only the useful message fields, such as `source`, `file_name`, and `file_count`.
+
+The unused `notice` color configuration was removed, tests now assert green `[info] resource_created` output without `kind=resource` or `[notice]`, and ADR 0006 records the decision to keep runtime logs inline and simple.
+
+## What we learned
+
+Logger appearance should be verified with representative output, not just configuration assertions. Small operational logs should stay close to the workflow that emits them unless there is a real operational need for a helper, metadata, or a structured logging layer.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -398,16 +398,6 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp log_resource_created(source, %DownloadedFile{file_name: file_name}) do
-    Logger.notice("resource_created source=#{source} file_name=#{file_name}", kind: :resource)
-  end
-
-  defp log_resources_created(source, files) when is_list(files) do
-    Logger.notice("resource_created source=#{source} file_count=#{length(files)}",
-      kind: :resource
-    )
-  end
-
   defp video_thumbnail(video) do
     Map.get(video, :thumbnail) || Map.get(video, :thumb)
   end
@@ -608,7 +598,11 @@ defmodule SaveIt.Bot do
         delete_message(context.chat_id, context.progress_message_id)
         FileHelper.write_folder(context.purge_url, files)
         GoogleDrive.upload_files(context.chat_id, files)
-        log_resources_created(:url_download, files)
+
+        Logger.info("resource_created source=url_download file_count=#{length(files)}",
+          ansi_color: :green
+        )
+
         :ok
 
       {:error, reason} ->
@@ -837,7 +831,11 @@ defmodule SaveIt.Bot do
     delete_message(context.chat_id, context.progress_message_id)
     FileHelper.write_file(file.file_name, file.file_content, context.original_url)
     GoogleDrive.upload_file_content(context.chat_id, file.file_content, file.file_name)
-    log_resource_created(:thumbnail_fallback, file)
+
+    Logger.info("resource_created source=thumbnail_fallback file_name=#{file.file_name}",
+      ansi_color: :green
+    )
+
     :ok
   end
 
@@ -845,7 +843,11 @@ defmodule SaveIt.Bot do
     delete_message(context.chat_id, context.progress_message_id)
     FileHelper.write_file(file.file_name, file.file_content, context.cache_url)
     GoogleDrive.upload_file_content(context.chat_id, file.file_content, file.file_name)
-    log_resource_created(:url_download, file)
+
+    Logger.info("resource_created source=url_download file_name=#{file.file_name}",
+      ansi_color: :green
+    )
+
     :ok
   end
 

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -265,7 +265,7 @@ defmodule SaveIt.BotTest do
         assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
       end)
 
-    refute log =~ "[notice] resource_created"
+    refute log =~ "resource_created"
     refute log =~ "download_file started"
     refute log =~ "download_file succeeded"
     refute log =~ "File.write succeeded"
@@ -376,8 +376,11 @@ defmodule SaveIt.BotTest do
 
     refute log =~ "Link preview metadata fetched"
     refute log =~ "Link preview caption selected"
-    assert log =~ "[notice] resource_created"
+    assert log =~ "[info] resource_created"
+    assert log =~ IO.ANSI.green()
     assert log =~ "source=url_download"
+    refute log =~ "kind=resource"
+    refute log =~ "[notice]"
     refute log =~ "download_file started"
     refute log =~ "download_file succeeded"
     refute log =~ "File.write succeeded"

--- a/test/logger_config_test.exs
+++ b/test/logger_config_test.exs
@@ -5,16 +5,36 @@ defmodule SaveIt.LoggerConfigTest do
   @test_config Path.expand("../config/test.exs", __DIR__)
   @runtime_config Path.expand("../config/runtime.exs", __DIR__)
 
-  test "runtime logger uses green only for resource creation notices" do
+  test "runtime logger keeps ordinary informational logs uncolored" do
     assert Application.fetch_env!(:logger, :level) == :info
 
     logger_config = Application.fetch_env!(:logger, :default_formatter)
 
     assert logger_config[:metadata] == [:status, :file_id, :kind]
     assert logger_config[:colors][:info] == :normal
-    assert logger_config[:colors][:notice] == :green
     assert logger_config[:colors][:warning] == :yellow
     assert logger_config[:colors][:error] == :red
+  end
+
+  test "resource creation info logs can opt into green output" do
+    formatter =
+      Application.fetch_env!(:logger, :default_formatter)
+      |> Logger.Formatter.new()
+      |> elem(1)
+
+    info =
+      Logger.Formatter.format(
+        %{
+          level: :info,
+          msg: {:string, "resource_created"},
+          meta: %{ansi_color: :green, time: 0}
+        },
+        formatter
+      )
+      |> IO.chardata_to_string()
+
+    assert info =~ IO.ANSI.green()
+    assert info =~ "[info] resource_created"
   end
 
   test "compile config imports the current environment config" do


### PR DESCRIPTION
## Summary

- Replace resource creation `Logger.notice` calls with concise green `Logger.info` output.
- Inline resource creation log calls instead of wrapping them in private logging helpers.
- Remove unused `notice` logger color configuration and document the logging decision in ADR 0006.
- Add a postmortem for the logger color and logging abstraction issue.

## Why

Elixir's default logger formatter does not support a separate `notice` color key, and the helper abstraction plus `kind` metadata made a simple operational log harder to read. Resource creation logs should stay close to the code path, remain green for scanability, and avoid speculative metadata.

## Validation

- `mix test test/bot_test.exs test/logger_config_test.exs`
- `mix format --check-formatted`
- `git diff --check`

## Postmortem

- `docs/postmortem/2026-06-16-resource-creation-logger-color.md`
