### PR TITLE
fix: use URL captions for MissAV saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ before the CalVer migration retain their original version labels.
 
 ### Fixed
 
+- Use the original MissAV URL as the saved caption while still reading preview metadata for thumbnails and logging a scoped fallback when Cloudflare blocks server-side requests.
 - Use random UUIDv7 filenames for downloaded resources while preserving the original file extension.
 - Preserve URL video preview aspect ratios by sending accurate display dimensions and square-pixel Telegram covers/thumbnails.
 

--- a/docs/postmortem/2026-06-15-missav-link-preview-metadata.md
+++ b/docs/postmortem/2026-06-15-missav-link-preview-metadata.md
@@ -1,0 +1,17 @@
+# MissAV Link Preview Metadata
+
+## What happened
+
+A MissAV URL could produce a downloaded video resource, but the saved caption was not stable or traceable enough. Local processing could only derive a slug fallback such as `SDAM-101 Uncensored Leak`, while Telegram's client preview showed richer metadata that was not available to the bot.
+
+## Root cause
+
+The initial assumption conflated Telegram client previews with data exposed to bots. `SmallSdk.LinkPreview` also did not parse `meta[name=keywords]`, and the MissAV URL fallback ran before any HTTP preview request, so a `missav.ai` URL could return a slug title without even trying to read HTML. After reversing that order, ordinary server-side requests still receive a Cloudflare `403`, which means the rich Telegram client preview is not currently available through this server-side path or the Bot API payload. For user-visible captions, the original URL is the most reliable MissAV value.
+
+## Fix applied
+
+`SmallSdk.LinkPreview` now fetches preview HTML before considering URL fallback, and extracts `meta[name=keywords]` in addition to the existing `og:title`, `og:description`, and preview image fields. For `missav.ai` source URLs, the bot uses the original URL as the caption while still using readable preview metadata, or the scoped MissAV fallback, for thumbnail selection and diagnostics. When the MissAV preview request is blocked, the fallback derives a readable title from the page slug, builds the cover image URL from the observed MissAV cover path pattern, and logs the fallback reason without inventing unavailable description or keyword text. Bot coverage verifies both readable and blocked MissAV preview paths keep the caption as the source URL.
+
+## What we learned
+
+Successful media download, Telegram client preview generation, and bot-side metadata fetching are separate capabilities. Sites protected by bot challenges can still have predictable public preview assets, but those fallbacks should stay scoped to the specific host and should log why fallback was selected. Captions should prefer values that the bot can reliably prove, rather than metadata visible only in a Telegram client preview.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -855,7 +855,11 @@ defmodule SaveIt.Bot do
         caption
 
       _ ->
-        link_preview_caption(message, original_url, metadata)
+        if missav_url?(original_url) do
+          original_url
+        else
+          link_preview_caption(message, original_url, metadata)
+        end
     end
   end
 
@@ -972,6 +976,22 @@ defmodule SaveIt.Bot do
   end
 
   defp x_url?(_url), do: false
+
+  defp missav_url?(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{host: host} when is_binary(host) ->
+        host = String.downcase(host)
+
+        host == "missav.ai" or String.ends_with?(host, ".missav.ai")
+
+      _ ->
+        false
+    end
+  rescue
+    _ -> false
+  end
+
+  defp missav_url?(_url), do: false
 
   defp send_message(chat_id, text) do
     ExGram.send_message(chat_id, text)

--- a/lib/small_sdk/link_preview.ex
+++ b/lib/small_sdk/link_preview.ex
@@ -27,6 +27,11 @@ defmodule SmallSdk.LinkPreview do
     ~r/<meta[^>]+(?:content|value)=["']([^"']+)["'][^>]+property=["']og:title["']/i
   ]
 
+  @keywords_patterns [
+    ~r/<meta[^>]+name=["']keywords["'][^>]+(?:content|value)=["']([^"']+)["']/i,
+    ~r/<meta[^>]+(?:content|value)=["']([^"']+)["'][^>]+name=["']keywords["']/i
+  ]
+
   def download_image(page_url) when is_binary(page_url) do
     case get_image_url(page_url) do
       {:ok, image_url} -> WebDownloader.download_file(image_url)
@@ -67,7 +72,22 @@ defmodule SmallSdk.LinkPreview do
   def get_title(_page_url), do: {:error, :missing_preview_url}
 
   def get_metadata(page_url) when is_binary(page_url) do
-    case Req.get(page_url, headers: [{"User-Agent", "Mozilla/5.0"}]) do
+    fetch_metadata(page_url)
+  end
+
+  def get_metadata(_page_url), do: {:error, :missing_preview_url}
+
+  def get_metadata_from_url_fallback(page_url) when is_binary(page_url) do
+    with {:ok, metadata} <- missav_metadata_from_url(page_url) do
+      log_metadata(page_url, metadata)
+      {:ok, metadata}
+    end
+  end
+
+  def get_metadata_from_url_fallback(_page_url), do: {:error, :missing_preview_url}
+
+  defp fetch_metadata(page_url) do
+    case Req.get(page_url, link_preview_req_options()) do
       {:ok, %{status: status, body: body}} when status in 200..209 and is_binary(body) ->
         metadata = get_metadata_from_html(page_url, body)
         log_metadata(page_url, metadata)
@@ -75,21 +95,25 @@ defmodule SmallSdk.LinkPreview do
 
       {:ok, %{status: status}} ->
         reason = {:preview_page_status, status}
-        log_metadata_error(page_url, reason)
-        {:error, reason}
+        get_metadata_from_url_fallback(page_url, reason)
 
       {:error, reason} ->
-        log_metadata_error(page_url, reason)
-        {:error, reason}
+        get_metadata_from_url_fallback(page_url, reason)
     end
   end
 
-  def get_metadata(_page_url), do: {:error, :missing_preview_url}
+  defp link_preview_req_options do
+    Keyword.merge(
+      [headers: [{"User-Agent", "Mozilla/5.0"}]],
+      Application.get_env(:save_it, :link_preview_req_options, [])
+    )
+  end
 
   def get_metadata_from_html(page_url, html) when is_binary(page_url) and is_binary(html) do
     %{
       title: html |> extract_title() |> blank_to_nil(),
       description: html |> extract_description() |> blank_to_nil(),
+      keywords: html |> extract_keywords() |> blank_to_nil(),
       image_url:
         html |> extract_image_url() |> resolve_image_url_value(page_url) |> blank_to_nil()
     }
@@ -142,6 +166,113 @@ defmodule SmallSdk.LinkPreview do
     end)
   end
 
+  defp extract_keywords(html) do
+    Enum.find_value(@keywords_patterns, fn pattern ->
+      case Regex.run(pattern, html) do
+        [_, keywords] -> normalize_html_value(keywords)
+        _ -> nil
+      end
+    end)
+  end
+
+  defp missav_metadata_from_url(page_url) do
+    uri = URI.parse(page_url)
+
+    with true <- missav_host?(uri.host),
+         {:ok, slug} <- slug_from_path(uri.path) do
+      title = title_from_slug(slug)
+
+      {:ok,
+       %{
+         title: title,
+         description: nil,
+         keywords: nil,
+         image_url: missav_cover_url(slug)
+       }}
+    else
+      _ -> {:error, :no_url_metadata_fallback}
+    end
+  rescue
+    _ -> {:error, :no_url_metadata_fallback}
+  end
+
+  defp missav_host?(host) when is_binary(host) do
+    host = String.downcase(host)
+    host == "missav.ai" or String.ends_with?(host, ".missav.ai")
+  end
+
+  defp missav_host?(_host), do: false
+
+  defp slug_from_path(path) when is_binary(path) do
+    path
+    |> String.split("/", trim: true)
+    |> List.last()
+    |> case do
+      slug when is_binary(slug) and slug != "" ->
+        if String.contains?(slug, "-") do
+          {:ok, slug}
+        else
+          {:error, :invalid_missav_slug}
+        end
+
+      _ ->
+        {:error, :missing_missav_slug}
+    end
+  end
+
+  defp slug_from_path(_path), do: {:error, :missing_missav_slug}
+
+  defp get_metadata_from_url_fallback(page_url, reason) when is_binary(page_url) do
+    case get_metadata_from_url_fallback(page_url) do
+      {:ok, metadata} ->
+        log_metadata_fallback(page_url, reason, metadata)
+        {:ok, metadata}
+
+      {:error, _fallback_reason} ->
+        log_metadata_error(page_url, reason)
+        {:error, reason}
+    end
+  end
+
+  defp get_metadata_from_url_fallback(_page_url, reason), do: {:error, reason}
+
+  defp title_from_slug(slug) do
+    slug
+    |> String.split("-", trim: true)
+    |> title_parts_from_slug_parts()
+    |> Enum.join(" ")
+  end
+
+  defp title_parts_from_slug_parts([letters, numbers | rest])
+       when is_binary(letters) and is_binary(numbers) do
+    if Regex.match?(~r/^[a-z]+$/i, letters) and Regex.match?(~r/^\d+[a-z]?$/i, numbers) do
+      [
+        String.upcase(letters) <> "-" <> String.upcase(numbers)
+        | Enum.map(rest, &titleize_slug_part/1)
+      ]
+    else
+      Enum.map([letters, numbers | rest], &titleize_slug_part/1)
+    end
+  end
+
+  defp title_parts_from_slug_parts(parts), do: Enum.map(parts, &titleize_slug_part/1)
+
+  defp titleize_slug_part(part) do
+    case String.split_at(part, 1) do
+      {"", ""} -> ""
+      {first, rest} -> String.upcase(first) <> String.downcase(rest)
+    end
+  end
+
+  defp missav_cover_url(slug) do
+    base_url =
+      :save_it
+      |> Application.get_env(:missav_cover_base_url, "https://fourhoi.com")
+      |> String.trim_trailing("/")
+
+    base_url <> "/" <> slug <> "/cover-n.jpg"
+  end
+
   defp resolve_image_url_value(nil, _page_url), do: nil
 
   defp resolve_image_url_value(image_url, page_url) do
@@ -163,6 +294,7 @@ defmodule SmallSdk.LinkPreview do
         "page_url=#{format_log_url(page_url)} " <>
         "og_title=#{format_log_value(metadata.title)} " <>
         "og_description=#{format_log_value(metadata.description)} " <>
+        "keywords=#{format_log_value(Map.get(metadata, :keywords))} " <>
         "og_image=#{format_log_url(metadata.image_url)}",
       kind: :link_preview
     )
@@ -173,6 +305,17 @@ defmodule SmallSdk.LinkPreview do
       "Link preview metadata fetch failed: " <>
         "page_url=#{format_log_url(page_url)} " <>
         "reason=#{format_log_reason(reason)}",
+      kind: :link_preview
+    )
+  end
+
+  defp log_metadata_fallback(page_url, reason, metadata) do
+    Logger.warning(
+      "Link preview metadata fallback selected: " <>
+        "page_url=#{format_log_url(page_url)} " <>
+        "reason=#{format_log_reason(reason)} " <>
+        "fallback_title=#{format_log_value(Map.get(metadata, :title))} " <>
+        "fallback_image=#{format_log_url(Map.get(metadata, :image_url))}",
       kind: :link_preview
     )
   end

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -739,6 +739,144 @@ defmodule SaveIt.BotTest do
     assert_storage_file_content_with_uuidv7_extension(".jpg", test_og_jpeg())
   end
 
+  test "uses the MissAV URL as the caption while still fetching readable preview metadata", %{
+    base_url: base_url
+  } do
+    original_url = "https://missav.ai/ja/readable-missav-page"
+    download_url = base_url <> "/downloaded/video.mp4"
+
+    Application.put_env(:ex_gram, :adapter, __MODULE__.UrlVideoWithoutThumbnailAdapter)
+    Application.put_env(:save_it, :missav_preview_image_url, base_url <> "/missav-cover.jpg")
+
+    Application.put_env(:save_it, :link_preview_req_options,
+      adapter: &__MODULE__.ReadableMissavPreviewAdapter.request/1
+    )
+
+    message = %{
+      chat: %{id: 12_345, username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 106,
+      text: original_url,
+      link_preview_options: %{url: original_url}
+    }
+
+    assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => original_url}
+    assert_receive {:test_http_request, :get, "/downloaded/video.mp4", ""}
+    assert_receive {:missav_preview_request, "https://missav.ai/ja/readable-missav-page"}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendVideo", {:multipart, parts}}
+    assert multipart_part(parts, "caption") == original_url
+
+    assert_receive {:test_http_request, :get, "/missav-cover.jpg", ""}
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    assert document["thumbnail_url"] == base_url <> "/missav-cover.jpg"
+    assert document["caption"] == original_url
+    assert document["file_id"] == "sent-video-file-id"
+    assert document["media_type"] == "video"
+    assert document["image"] == Base.encode64(test_og_jpeg())
+  end
+
+  test "indexes a MissAV video using fallback metadata when the preview page is blocked", %{
+    base_url: base_url
+  } do
+    original_url = "https://missav.ai/ja/sdam-101-uncensored-leak"
+    download_url = base_url <> "/downloaded/video.mp4"
+
+    Application.put_env(:ex_gram, :adapter, __MODULE__.UrlVideoWithoutThumbnailAdapter)
+    Application.put_env(:save_it, :missav_cover_base_url, base_url)
+
+    Application.put_env(:save_it, :link_preview_req_options,
+      adapter: &__MODULE__.BlockedMissavPreviewAdapter.request/1
+    )
+
+    message = %{
+      chat: %{id: 12_345, username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 106,
+      text: original_url,
+      link_preview_options: %{url: original_url}
+    }
+
+    log =
+      capture_log(fn ->
+        assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+      end)
+
+    refute log =~ "Link preview metadata fetch failed"
+    assert log =~ "Link preview metadata fallback selected"
+    assert log =~ "reason={:preview_page_status, 403}"
+    assert_receive {:missav_preview_request, "https://missav.ai/ja/sdam-101-uncensored-leak"}
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => original_url}
+    assert_receive {:test_http_request, :get, "/downloaded/video.mp4", ""}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendVideo", {:multipart, parts}}
+    assert multipart_part(parts, "caption") == original_url
+
+    assert_receive {:test_http_request, :get, "/sdam-101-uncensored-leak/cover-n.jpg", ""}
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    assert document["thumbnail_url"] == base_url <> "/sdam-101-uncensored-leak/cover-n.jpg"
+    assert document["caption"] == original_url
+    assert document["file_id"] == "sent-video-file-id"
+    assert document["media_type"] == "video"
+    assert document["image"] == Base.encode64(test_og_jpeg())
+  end
+
+  test "uses the MissAV source URL as the caption when preview html is readable", %{
+    base_url: base_url
+  } do
+    original_url = "https://missav.ai/ja/readable-missav-page"
+    preview_url = base_url <> "/missav-page"
+    download_url = base_url <> "/downloaded/video.mp4"
+
+    Application.put_env(:ex_gram, :adapter, __MODULE__.UrlVideoWithoutThumbnailAdapter)
+
+    message = %{
+      chat: %{id: 12_345, username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 107,
+      text: original_url,
+      link_preview_options: %{url: preview_url}
+    }
+
+    assert {:ok, true} = Bot.handle({:text, original_url, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => original_url}
+    assert_receive {:test_http_request, :get, "/downloaded/video.mp4", ""}
+    assert_receive {:test_http_request, :get, "/missav-page", ""}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendVideo", {:multipart, parts}}
+    assert multipart_part(parts, "caption") == original_url
+
+    assert_receive {:test_http_request, :get, "/missav-cover.jpg", ""}
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["download_url"] == download_url
+    assert document["thumbnail_url"] == base_url <> "/missav-cover.jpg"
+    assert document["caption"] == original_url
+    assert document["file_id"] == "sent-video-file-id"
+    assert document["media_type"] == "video"
+    assert document["image"] == Base.encode64(test_og_jpeg())
+  end
+
   test "stores the webpage preview for a downloaded HLS URL video", %{base_url: base_url} do
     original_url = base_url <> "/hls-video-page"
 
@@ -1963,6 +2101,47 @@ defmodule SaveIt.BotTest do
     end
   end
 
+  defmodule ReadableMissavPreviewAdapter do
+    def request(%Req.Request{method: :get} = request) do
+      send(self(), {:missav_preview_request, URI.to_string(request.url)})
+
+      image_url = Application.fetch_env!(:save_it, :missav_preview_image_url)
+
+      body = """
+      <!doctype html>
+      <html>
+        <head>
+          <meta property="og:title" content="MissAV OG Title">
+          <meta property="og:description" content="MissAV OG Description">
+          <meta name="keywords" content="missav, sdam-101, uncensored leak">
+          <meta property="og:image" content="#{image_url}">
+        </head>
+        <body>missav preview</body>
+      </html>
+      """
+
+      {request,
+       %Req.Response{
+         status: 200,
+         headers: %{"content-type" => ["text/html"]},
+         body: body
+       }}
+    end
+  end
+
+  defmodule BlockedMissavPreviewAdapter do
+    def request(%Req.Request{method: :get} = request) do
+      send(self(), {:missav_preview_request, URI.to_string(request.url)})
+
+      {request,
+       %Req.Response{
+         status: 403,
+         headers: %{"content-type" => ["text/html"]},
+         body: "blocked"
+       }}
+    end
+  end
+
   defmodule TestHttpServer do
     use GenServer
 
@@ -2176,6 +2355,30 @@ defmodule SaveIt.BotTest do
       """
     end
 
+    defp response_for("/missav-page", port, _body) do
+      html = """
+      <!doctype html>
+      <html>
+        <head>
+          <meta property="og:title" content="MissAV OG Title">
+          <meta property="og:description" content="MissAV OG Description">
+          <meta name="keywords" content="missav, sdam-101, uncensored leak">
+          <meta property="og:image" content="http://127.0.0.1:#{port}/missav-cover.jpg">
+        </head>
+        <body>missav preview</body>
+      </html>
+      """
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: text/html\r
+      content-length: #{byte_size(html)}\r
+      connection: close\r
+      \r
+      #{html}
+      """
+    end
+
     defp response_for("/youtube-page", port, _body) do
       html = """
       <!doctype html>
@@ -2282,6 +2485,32 @@ defmodule SaveIt.BotTest do
       """
     end
 
+    defp response_for("/sdam-101-uncensored-leak/cover-n.jpg", _port, _body) do
+      jpeg = SaveIt.BotTest.test_og_jpeg()
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: image/jpeg\r
+      content-length: #{byte_size(jpeg)}\r
+      connection: close\r
+      \r
+      #{jpeg}
+      """
+    end
+
+    defp response_for("/missav-cover.jpg", _port, _body) do
+      jpeg = SaveIt.BotTest.test_og_jpeg()
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: image/jpeg\r
+      content-length: #{byte_size(jpeg)}\r
+      connection: close\r
+      \r
+      #{jpeg}
+      """
+    end
+
     defp response_for("/preview.jpg", _port, _body) do
       jpeg = <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70>>
 
@@ -2324,6 +2553,14 @@ defmodule SaveIt.BotTest do
     end
 
     defp cobalt_response(%{"url" => "https://www.youtube.com/shorts/clip123"}, port) do
+      json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/video.mp4"})
+    end
+
+    defp cobalt_response(%{"url" => "https://missav.ai/ja/sdam-101-uncensored-leak"}, port) do
+      json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/video.mp4"})
+    end
+
+    defp cobalt_response(%{"url" => "https://missav.ai/ja/readable-missav-page"}, port) do
       json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/video.mp4"})
     end
 

--- a/test/small_sdk/link_preview_test.exs
+++ b/test/small_sdk/link_preview_test.exs
@@ -73,7 +73,45 @@ defmodule SmallSdk.LinkPreviewTest do
     assert LinkPreview.get_metadata_from_html("https://example.com/posts/1", html) == %{
              title: "Preview Page OG Title",
              description: "Preview Page OG Description",
+             keywords: nil,
              image_url: "https://example.com/preview.jpg"
            }
+  end
+
+  test "extracts og title, og description, and meta keywords from html" do
+    html = """
+    <html>
+      <head>
+        <meta property="og:title" content="MissAV OG Title" />
+        <meta property="og:description" content="MissAV OG Description" />
+        <meta name="keywords" content="missav, sdam-101, uncensored leak" />
+        <meta property="og:image" content="/cover-n.jpg" />
+      </head>
+    </html>
+    """
+
+    assert LinkPreview.get_metadata_from_html(
+             "https://missav.ai/ja/sdam-101-uncensored-leak",
+             html
+           ) ==
+             %{
+               title: "MissAV OG Title",
+               description: "MissAV OG Description",
+               keywords: "missav, sdam-101, uncensored leak",
+               image_url: "https://missav.ai/cover-n.jpg"
+             }
+  end
+
+  test "builds MissAV fallback metadata from the page URL" do
+    assert LinkPreview.get_metadata_from_url_fallback(
+             "https://missav.ai/ja/sdam-101-uncensored-leak"
+           ) ==
+             {:ok,
+              %{
+                title: "SDAM-101 Uncensored Leak",
+                description: nil,
+                keywords: nil,
+                image_url: "https://fourhoi.com/sdam-101-uncensored-leak/cover-n.jpg"
+              }}
   end
 end


### PR DESCRIPTION
## Summary

- use the original MissAV URL as the saved caption instead of Open Graph text or slug fallback text
- keep MissAV preview metadata fetching for thumbnail selection and fallback diagnostics
- document the Cloudflare/Bot API limitation in the postmortem and changelog

## Root cause

Telegram clients can show richer link preview metadata than the Bot API exposes, and server-side MissAV preview requests can be blocked by Cloudflare. The previous MissAV caption behavior depended on metadata that is not reliably available to the bot.

## Validation

- `mix format --check-formatted`
- `MIX_ENV=test mix test test/small_sdk/link_preview_test.exs test/bot_test.exs` — 44 tests, 0 failures
- `MIX_ENV=test mix test` — 87 tests, 0 failures
- `git diff --check`
