### PR TITLE
feat: save og:image for non-media URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ before the CalVer migration retain their original version labels.
 ### Fixed
 
 - Render successful resource creation info logs in green in runtime logger output.
+- Save a webpage `og:image` preview when a URL resolves to a non-media resource instead of storing the resolved HTML or document file.
 - Send and index a generated preview image when a downloaded URL video is too large for Telegram video upload, while still saving the downloaded video locally.
 - Use random UUIDv7 filenames for downloaded resources while preserving the original file extension.
 - Preserve URL video preview aspect ratios by sending accurate display dimensions and square-pixel Telegram covers/thumbnails.

--- a/docs/postmortem/2026-06-16-non-media-url-og-image-fallback.md
+++ b/docs/postmortem/2026-06-16-non-media-url-og-image-fallback.md
@@ -1,0 +1,23 @@
+# Non-Media URL Open Graph Image Fallback
+
+## What happened
+
+When a URL resolved to a downloadable resource that was not an image, video, or animation, `save_it` treated the resolved resource as a successful URL download. For article-like pages this could save and send an HTML/document file, while skipping the existing Open Graph image fallback path that would create a searchable photo preview.
+
+## Root cause
+
+The single-file URL download path considered any successful HTTP download complete. Media routing happened later by file extension, so non-media files were sent as Telegram documents and were not indexed in Typesense. The fallback logic that saves Telegram thumbnails or webpage `og:image` previews only ran when resolving or downloading the URL failed.
+
+The thumbnail fallback also accepted `store_download_url?: false`, but the existing `download_url` option could remain in the keyword list. That allowed a failed or non-media resolved URL to leak into the fallback document metadata.
+
+## Fix applied
+
+The single-file download path now checks whether the downloaded filename is a supported URL media file before sending and finalizing it. Non-media downloads route through the existing thumbnail fallback, so pages with `og:image` are saved as photo previews and indexed with URL metadata.
+
+Fallback sends now remove any existing `download_url` before optionally adding the intended one. This keeps fallback documents from storing the non-media resolved URL.
+
+Metadata fetching for thumbnail fallback now fetches the original URL when no Telegram preview URL exists, so user-captioned URL pages can still store `thumbnail_url`, `title`, `description`, and `keywords`.
+
+## What we learned
+
+Download success is not the same as save success. URL saves need a media-type boundary before finalization so HTML or document responses can degrade to preview image saving instead of bypassing search indexing. Boolean options that suppress metadata should delete stale keyword values, not only avoid adding new ones.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -690,7 +690,14 @@ defmodule SaveIt.Bot do
   defp handle_non_media_download(%DownloadContext{} = context) do
     case download_fallback_thumbnail(context) do
       {:ok, %DownloadedFile{} = file, source} ->
-        log_non_media_fallback_success(source)
+        case source do
+          :telegram_thumbnail ->
+            Logger.warning("Saved Telegram thumbnail fallback after non-media URL download")
+
+          :webpage_preview ->
+            Logger.warning("Saved webpage preview fallback after non-media URL download")
+        end
+
         save_thumbnail_fallback(context, file, source)
 
       {:error, _fallback_reasons} ->
@@ -737,14 +744,6 @@ defmodule SaveIt.Bot do
 
   defp log_thumbnail_fallback_success(:webpage_preview) do
     Logger.warning("Saved webpage preview fallback after link download failed")
-  end
-
-  defp log_non_media_fallback_success(:telegram_thumbnail) do
-    Logger.warning("Saved Telegram thumbnail fallback after non-media URL download")
-  end
-
-  defp log_non_media_fallback_success(:webpage_preview) do
-    Logger.warning("Saved webpage preview fallback after non-media URL download")
   end
 
   defp save_thumbnail_fallback(%DownloadContext{} = context, %DownloadedFile{} = file, source) do

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -668,14 +668,36 @@ defmodule SaveIt.Bot do
             "download_url=#{format_log_url(context.download_url)}"
         )
 
-        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+        if url_download_media_file?(file.file_name) do
+          update_message(
+            context.chat_id,
+            context.progress_message_id,
+            Enum.slice(@progress, 0..2)
+          )
 
-        bot_send_downloaded_file(context.chat_id, file, download_send_opts(context))
+          bot_send_downloaded_file(context.chat_id, file, download_send_opts(context))
 
-        finalize_single_download(context, file)
+          finalize_single_download(context, file)
+        else
+          handle_non_media_download(context)
+        end
 
       {:error, reason} ->
         handle_download_failure(context, "💔 Failed downloading file.", reason)
+    end
+  end
+
+  defp handle_non_media_download(%DownloadContext{} = context) do
+    case download_fallback_thumbnail(context) do
+      {:ok, %DownloadedFile{} = file, source} ->
+        log_non_media_fallback_success(source)
+        save_thumbnail_fallback(context, file, source)
+
+      {:error, _fallback_reasons} ->
+        Logger.warning("No thumbnail fallback available after non-media URL download")
+
+        update_message(context.chat_id, context.progress_message_id, "💔 No image preview found.")
+        :error
     end
   end
 
@@ -715,6 +737,14 @@ defmodule SaveIt.Bot do
 
   defp log_thumbnail_fallback_success(:webpage_preview) do
     Logger.warning("Saved webpage preview fallback after link download failed")
+  end
+
+  defp log_non_media_fallback_success(:telegram_thumbnail) do
+    Logger.warning("Saved Telegram thumbnail fallback after non-media URL download")
+  end
+
+  defp log_non_media_fallback_success(:webpage_preview) do
+    Logger.warning("Saved webpage preview fallback after non-media URL download")
   end
 
   defp save_thumbnail_fallback(%DownloadContext{} = context, %DownloadedFile{} = file, source) do
@@ -759,8 +789,7 @@ defmodule SaveIt.Bot do
     preview_url = link_preview_url(message)
     fetch_original? = user_text_caption(message) == ""
 
-    thumbnail_needs_metadata? =
-      Keyword.get(opts, :store_thumbnail_url?, true) and is_binary(preview_url)
+    thumbnail_needs_metadata? = Keyword.get(opts, :store_thumbnail_url?, true)
 
     UrlMetadata.metadata_page_url(original_url, preview_url,
       fetch_original?: fetch_original? or thumbnail_needs_metadata?
@@ -1010,14 +1039,13 @@ defmodule SaveIt.Bot do
 
   defp bot_send_downloaded_file(chat_id, %DownloadedFile{} = file, opts) do
     store_download_url? = Keyword.get(opts, :store_download_url?, true)
+    download_url = download_url_for_file(file, opts, store_download_url?)
 
     opts =
       opts
       |> Keyword.delete(:store_download_url?)
-      |> put_optional_keyword(
-        :download_url,
-        download_url_for_file(file, opts, store_download_url?)
-      )
+      |> Keyword.delete(:download_url)
+      |> put_optional_keyword(:download_url, download_url)
 
     bot_send_file(
       chat_id,
@@ -1546,6 +1574,10 @@ defmodule SaveIt.Bot do
 
   defp image_file?(file_name) do
     file_extension(file_name) in [".png", ".jpg", ".jpeg"]
+  end
+
+  defp url_download_media_file?(file_name) do
+    file_extension(file_name) in [".png", ".jpg", ".jpeg", ".mp4", ".gif"]
   end
 
   defp encode_file_content({:file, file}) do

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -606,6 +606,53 @@ defmodule SaveIt.BotTest do
            end)
   end
 
+  test "stores og image when the resolved URL resource is not image or video", %{
+    base_url: base_url
+  } do
+    original_url = base_url <> "/article-page"
+    message_text = "read later #{original_url}"
+
+    message = %{
+      chat: %{id: 12_345, username: "save_it_test_chat"},
+      date: 1_717_170_000,
+      message_id: 108,
+      text: message_text,
+      entities: [%{offset: 11, type: "url", length: String.length(original_url)}]
+    }
+
+    log =
+      capture_log(fn ->
+        assert {:ok, true} = Bot.handle({:text, message_text, message}, nil)
+      end)
+
+    assert log =~ "Saved webpage preview fallback after non-media URL download"
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => original_url}
+
+    assert_receive {:test_http_request, :get, "/downloaded/article.html", ""}
+    assert_receive {:test_http_request, :get, "/article-page", ""}
+    assert_receive {:test_http_request, :get, "/preview.jpg", ""}
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    refute Map.has_key?(document, "download_url")
+    assert document["thumbnail_url"] == base_url <> "/preview.jpg"
+    assert document["caption"] == "read later"
+    assert document["title"] == "Article Page OG Title"
+    assert document["description"] == "Article Page OG Description"
+    assert document["keywords"] == ["article", "preview", "save-it"]
+    assert document["file_id"] == "telegram-photo-file-id"
+    assert document["image"] == Base.encode64(test_jpeg())
+
+    refute Enum.any?(exgram_calls(), fn
+             {:post, :send_document, _body} -> true
+             _ -> false
+           end)
+  end
+
   test "indexes a downloaded URL video using a generated cover before Telegram and webpage previews",
        %{base_url: base_url} do
     original_url = base_url <> "/video-page-with-telegram-thumbnail"
@@ -2400,6 +2447,30 @@ defmodule SaveIt.BotTest do
       """
     end
 
+    defp response_for("/article-page", port, _body) do
+      html = """
+      <!doctype html>
+      <html>
+        <head>
+          <meta property="og:title" content="Article Page OG Title">
+          <meta property="og:description" content="Article Page OG Description">
+          <meta name="keywords" content="article, preview, save-it">
+          <meta property="og:image" content="http://127.0.0.1:#{port}/preview.jpg">
+        </head>
+        <body>article preview</body>
+      </html>
+      """
+
+      """
+      HTTP/1.1 200 OK\r
+      content-type: text/html\r
+      content-length: #{byte_size(html)}\r
+      connection: close\r
+      \r
+      #{html}
+      """
+    end
+
     defp response_for(path, port, _body)
          when path in ["/video-page", "/video-page-with-telegram-thumbnail", "/large-video-page"] do
       html = """
@@ -2515,6 +2586,9 @@ defmodule SaveIt.BotTest do
       cond do
         String.contains?(url, "/photo-page") ->
           json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg"})
+
+        String.contains?(url, "/article-page") ->
+          json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/article.html"})
 
         String.contains?(url, "/video-page") ->
           json_response(%{"url" => "http://127.0.0.1:#{port}/downloaded/video.mp4"})


### PR DESCRIPTION
## Summary
- Route non-media URL downloads through the existing thumbnail fallback instead of saving resolved HTML or document resources.
- Fetch original URL metadata for fallback saves when Telegram does not provide a preview URL, preserving `thumbnail_url`, title, description, and keywords.
- Add regression coverage, changelog entry, and postmortem for the non-media URL fallback path.

## Why
Some URLs resolve successfully to non-media resources, such as article HTML. The previous flow treated that as a completed download, sent a Telegram document, and skipped `og:image` indexing. This keeps those saves searchable as photo previews instead.

## Test Plan
- [x] `mix test`
