### PR TITLE
fix: improve video preview clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ before the CalVer migration retain their original version labels.
 - Send and index a generated preview image when a downloaded URL video is too large for Telegram video upload, while still saving the downloaded video locally.
 - Use random UUIDv7 filenames for downloaded resources while preserving the original file extension.
 - Preserve URL video preview aspect ratios by sending accurate display dimensions and square-pixel Telegram covers/thumbnails.
+- Improve generated video preview clarity by sending higher-resolution Telegram covers while keeping thumbnails within Telegram limits.
 
 ## [2026.6.15] - 2026-06-15
 

--- a/docs/postmortem/2026-06-16-video-preview-clarity.md
+++ b/docs/postmortem/2026-06-16-video-preview-clarity.md
@@ -1,0 +1,17 @@
+# Video Preview Clarity
+
+## What happened
+
+Generated video previews looked blurry in Telegram and in the saved search preview. The bot generated a square-pixel JPEG with the correct display aspect ratio, but the image was still much smaller than the source video frame.
+
+## Root cause
+
+The video preview pipeline used one generated image for both Telegram `cover` and `thumbnail`. That image was capped at 320 pixels on the longest side to satisfy Telegram's `thumbnail` requirements. The newer `cover` field is the visible video cover and does not need to share that low-resolution cap, so the bot was unnecessarily sending a small cover.
+
+## Fix applied
+
+`SaveIt.VideoUpload.cover/2` now generates a higher-resolution cover capped at 1920 pixels on the longest side without upscaling smaller videos, and also generates a separate Telegram-compliant thumbnail capped at 320 pixels. `sendVideo` uploads the high-resolution image as `cover` and the small image as `thumbnail`; Typesense indexing and oversized-video photo fallback continue to use the clearer cover image.
+
+## What we learned
+
+Telegram video `cover` and `thumbnail` are different API boundaries. Keep the thumbnail small and compatible, but do not let thumbnail constraints degrade the user-visible cover or search preview image.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -1426,15 +1426,29 @@ defmodule SaveIt.Bot do
 
   defp maybe_put_video_preview_files(
          opts,
-         {:ok, %{file_content: file_content, file_name: file_name}}
+         {:ok, %{file_content: file_content, file_name: file_name}} = video_cover
        )
        when is_binary(file_content) and is_binary(file_name) do
     opts
     |> Keyword.put(:cover, {:file_content, file_content, file_name})
-    |> Keyword.put(:thumbnail, {:file_content, file_content, file_name})
+    |> maybe_put_video_thumbnail_file(video_cover)
   end
 
   defp maybe_put_video_preview_files(opts, _video_cover), do: opts
+
+  defp maybe_put_video_thumbnail_file(
+         opts,
+         {:ok,
+          %{
+            thumbnail_file_content: file_content,
+            thumbnail_file_name: file_name
+          }}
+       )
+       when is_binary(file_content) and is_binary(file_name) do
+    Keyword.put(opts, :thumbnail, {:file_content, file_content, file_name})
+  end
+
+  defp maybe_put_video_thumbnail_file(opts, _video_cover), do: opts
 
   defp index_sent_video_preview(chat_id, msg, opts) do
     caption = Keyword.fetch!(opts, :caption)

--- a/lib/save_it/video_upload.ex
+++ b/lib/save_it/video_upload.ex
@@ -6,7 +6,10 @@ defmodule SaveIt.VideoUpload do
   alias SaveIt.FilenameGenerator
   alias SaveIt.VideoMetadata
 
-  @telegram_cover_max_dimension 320
+  @telegram_cover_max_dimension 1920
+  @telegram_thumbnail_max_dimension 320
+  @cover_jpeg_quality 2
+  @thumbnail_jpeg_quality 5
 
   def prepare({:file_content, file_content, file_name})
       when is_binary(file_content) and is_binary(file_name) do
@@ -38,11 +41,13 @@ defmodule SaveIt.VideoUpload do
     with {:ok, dimensions} <- cover_dimensions(metadata),
          {:ok, cover_content} <-
            cover_generator().cover_file_content(file_content, file_name, dimensions) do
-      {:ok,
-       %{
-         file_content: cover_content,
-         file_name: cover_file_name(file_name)
-       }}
+      cover =
+        %{
+          file_content: cover_content,
+          file_name: cover_file_name(file_name)
+        }
+
+      {:ok, put_video_thumbnail(cover, file_content, file_name, metadata)}
     else
       {:error, reason} ->
         Logger.debug("Skipping video cover upload: #{inspect(reason)}")
@@ -86,18 +91,45 @@ defmodule SaveIt.VideoUpload do
 
   defp cover_dimensions(%{width: width, height: height})
        when is_integer(width) and width > 0 and is_integer(height) and height > 0 do
-    scale = @telegram_cover_max_dimension / max(width, height)
-
-    {:ok,
-     %{
-       width: max(1, round(width * scale)),
-       height: max(1, round(height * scale))
-     }}
+    preview_dimensions(width, height, @telegram_cover_max_dimension, @cover_jpeg_quality)
   end
 
   defp cover_dimensions(_metadata), do: {:error, :missing_video_display_dimensions}
 
+  defp thumbnail_dimensions(%{width: width, height: height})
+       when is_integer(width) and width > 0 and is_integer(height) and height > 0 do
+    preview_dimensions(width, height, @telegram_thumbnail_max_dimension, @thumbnail_jpeg_quality)
+  end
+
+  defp thumbnail_dimensions(_metadata), do: {:error, :missing_video_display_dimensions}
+
+  defp preview_dimensions(width, height, max_dimension, jpeg_quality) do
+    scale = min(1.0, max_dimension / max(width, height))
+
+    {:ok,
+     %{
+       width: max(1, round(width * scale)),
+       height: max(1, round(height * scale)),
+       jpeg_quality: jpeg_quality
+     }}
+  end
+
   defp cover_file_name(_file_name), do: FilenameGenerator.random("cover.jpg")
+  defp thumbnail_file_name(_file_name), do: FilenameGenerator.random("thumbnail.jpg")
+
+  defp put_video_thumbnail(cover, file_content, file_name, metadata) do
+    with {:ok, dimensions} <- thumbnail_dimensions(metadata),
+         {:ok, thumbnail_content} <-
+           cover_generator().cover_file_content(file_content, file_name, dimensions) do
+      cover
+      |> Map.put(:thumbnail_file_content, thumbnail_content)
+      |> Map.put(:thumbnail_file_name, thumbnail_file_name(file_name))
+    else
+      {:error, reason} ->
+        Logger.debug("Skipping video thumbnail upload: #{inspect(reason)}")
+        cover
+    end
+  end
 
   defmodule FFmpegFaststart do
     @moduledoc false
@@ -167,10 +199,12 @@ defmodule SaveIt.VideoUpload do
   defmodule FFmpegCover do
     @moduledoc false
 
-    def cover_file_content(file_content, file_name, %{width: width, height: height})
+    def cover_file_content(file_content, file_name, %{width: width, height: height} = dimensions)
         when is_binary(file_content) and is_binary(file_name) and is_integer(width) and
                is_integer(height) do
       with_temp_files(file_name, file_content, fn input_path, output_path ->
+        jpeg_quality = Map.get(dimensions, :jpeg_quality, 2)
+
         args = [
           "-y",
           "-i",
@@ -181,7 +215,7 @@ defmodule SaveIt.VideoUpload do
           "-vf",
           "thumbnail,scale=#{width}:#{height},setsar=1",
           "-q:v",
-          "5",
+          "#{jpeg_quality}",
           "-loglevel",
           "warning",
           output_path

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -644,7 +644,7 @@ defmodule SaveIt.BotTest do
     assert multipart_part(parts, "height") == "1920"
     assert multipart_part(parts, "duration") == "12"
     assert multipart_part(parts, "thumbnail") == :file_content
-    assert multipart_file_content(parts, "thumbnail") == test_video_cover()
+    assert multipart_file_content(parts, "thumbnail") == test_video_thumbnail()
     assert multipart_part(parts, "cover") == :file_content
     assert multipart_file_content(parts, "cover") == test_video_cover()
 
@@ -1754,6 +1754,10 @@ defmodule SaveIt.BotTest do
     <<255, 216, 255, 224, 0, 16, 67, 79, 86, 69, 82>>
   end
 
+  def test_video_thumbnail do
+    <<255, 216, 255, 224, 0, 16, 84, 72, 85, 77, 66>>
+  end
+
   def test_mp4 do
     <<0, 0, 0, 24, 102, 116, 121, 112, 109, 112, 52, 50>>
   end
@@ -2001,14 +2005,19 @@ defmodule SaveIt.BotTest do
   end
 
   defmodule VideoCoverGenerator do
-    def cover_file_content(_file_content, file_name, %{width: 180, height: 320})
+    def cover_file_content(_file_content, file_name, %{width: 1080, height: 1920, jpeg_quality: 2})
         when is_binary(file_name) do
       {:ok, SaveIt.BotTest.test_video_cover()}
+    end
+
+    def cover_file_content(_file_content, file_name, %{width: 180, height: 320, jpeg_quality: 5})
+        when is_binary(file_name) do
+      {:ok, SaveIt.BotTest.test_video_thumbnail()}
     end
   end
 
   defmodule FailingVideoCoverGenerator do
-    def cover_file_content(_file_content, file_name, %{width: 180, height: 320})
+    def cover_file_content(_file_content, file_name, _dimensions)
         when is_binary(file_name) do
       {:error, :cover_unavailable}
     end

--- a/test/save_it/video_upload_test.exs
+++ b/test/save_it/video_upload_test.exs
@@ -13,7 +13,7 @@ defmodule SaveIt.VideoUploadTest do
     :ok
   end
 
-  test "generates square-pixel cover using the video display ratio" do
+  test "generates full-size cover and Telegram-compliant thumbnail using the video display ratio" do
     Application.put_env(:save_it, :video_cover_generator, __MODULE__.CoverGenerator)
 
     assert {:ok, cover} =
@@ -23,8 +23,24 @@ defmodule SaveIt.VideoUploadTest do
              })
 
     assert cover.file_content == "cover-bytes"
+    assert cover.thumbnail_file_content == "thumbnail-bytes"
     assert_uuidv7_filename(cover.file_name, ".jpg")
-    assert_received {:cover_dimensions, %{width: 90, height: 320}}
+    assert_uuidv7_filename(cover.thumbnail_file_name, ".jpg")
+    assert_received {:cover_dimensions, %{width: 180, height: 640, jpeg_quality: 2}}
+    assert_received {:cover_dimensions, %{width: 90, height: 320, jpeg_quality: 5}}
+  end
+
+  test "caps generated covers without upscaling smaller videos" do
+    Application.put_env(:save_it, :video_cover_generator, __MODULE__.CoverGenerator)
+
+    assert {:ok, _cover} =
+             VideoUpload.cover({:file_content, "video-bytes", "clip.mp4"}, %{
+               width: 2160,
+               height: 3840
+             })
+
+    assert_received {:cover_dimensions, %{width: 1080, height: 1920, jpeg_quality: 2}}
+    assert_received {:cover_dimensions, %{width: 180, height: 320, jpeg_quality: 5}}
   end
 
   defp assert_uuidv7_filename(file_name, extension) do
@@ -37,7 +53,11 @@ defmodule SaveIt.VideoUploadTest do
   defmodule CoverGenerator do
     def cover_file_content(_file_content, _file_name, dimensions) do
       send(self(), {:cover_dimensions, dimensions})
-      {:ok, "cover-bytes"}
+
+      case dimensions.jpeg_quality do
+        2 -> {:ok, "cover-bytes"}
+        5 -> {:ok, "thumbnail-bytes"}
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Generate a higher-resolution Telegram video cover capped at 1920px on the longest side without upscaling smaller videos.
- Generate a separate Telegram-compliant thumbnail capped at 320px, and send it separately from the visible cover.
- Keep Typesense video preview indexing and oversized-video preview fallback on the clearer cover image.

## Root Cause

The video preview pipeline reused one generated image for both Telegram `cover` and `thumbnail`. Because `thumbnail` must stay within Telegram's 320px limit, the visible `cover` was also unnecessarily small and blurry.

## Validation

- `mix test test/save_it/video_upload_test.exs test/bot_test.exs`
- `mix format --check-formatted`
- `git diff --check`
