### PR TITLE
chore: add setup dev and reset mix aliases

### DIFF
--- a/.agents/skills/save-it-development/SKILL.md
+++ b/.agents/skills/save-it-development/SKILL.md
@@ -18,7 +18,7 @@ Run from the repository root:
 ```bash
 mise trust
 mise install
-mix deps.get
+mix setup
 ```
 
 If `mise.toml` is missing in the current directory, move to the parent directory and retry the `mise` commands.
@@ -41,7 +41,7 @@ Run the bot:
 
 ```bash
 export TELEGRAM_BOT_TOKEN=<YOUR_TELEGRAM_BOT_TOKEN>
-iex -S mix run --no-halt
+mix dev
 ```
 
 ## Reset Local Data
@@ -50,7 +50,7 @@ Reset local Docker services and runtime data from the repository root:
 
 ```bash
 docker compose down --volumes
-rm -rf data
+mix reset
 ```
 
 ## Local Checks

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ Save the file as `cobalt-cookies.json` at the repository root before starting Do
 docker-compose --profile prod up -d
 ```
 
+## Development
+
+Local development commands are available as Mix aliases:
+
+```sh
+mix setup   # deps.get + ts.migrate
+mix dev     # run the bot with iex --no-halt
+mix reset   # remove local runtime data directory (`data`)
+```
+
 ## Build with
 
 - [Elixir](https://elixir-lang.org/)

--- a/mix.exs
+++ b/mix.exs
@@ -50,6 +50,9 @@ defmodule SaveIt.MixProject do
 
   defp aliases do
     [
+      setup: ["deps.get", "ts.migrate"],
+      dev: "run --no-halt",
+      reset: "cmd rm -rf data",
       coverage: "test --cover",
       "ts.migrate": &ts_migrate/1,
       "ts.rollback": &ts_rollback/1,

--- a/test/mix_project_test.exs
+++ b/test/mix_project_test.exs
@@ -15,6 +15,14 @@ defmodule SaveIt.MixProjectTest do
     assert SaveIt.MixProject.cli()[:preferred_envs][:coverage] == :test
   end
 
+  test "configures local development lifecycle aliases" do
+    aliases = SaveIt.MixProject.project() |> Keyword.fetch!(:aliases)
+
+    assert Keyword.fetch!(aliases, :setup) == ["deps.get", "ts.migrate"]
+    assert Keyword.fetch!(aliases, :dev) == "run --no-halt"
+    assert Keyword.fetch!(aliases, :reset) == "cmd rm -rf data"
+  end
+
   test "runs Typesense maintenance commands without compiling the application" do
     aliases = SaveIt.MixProject.project() |> Keyword.fetch!(:aliases)
 


### PR DESCRIPTION
## Summary
- switch setup/dev workflow in docs and skill guidance to mix aliases
  - `.agents/skills/save-it-development/SKILL.md`: use `mix setup`, `mix dev`, `mix reset`
  - `README.md`: add Development section listing `mix setup`, `mix dev`, `mix reset`

## Validation
- (No functional validation run in this docs-only update)
