### PR TITLE
[codex] fix: handle detail command for video replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ before the CalVer migration retain their original version labels.
 - Render successful resource creation info logs in green in runtime logger output.
 - Save a webpage `og:image` preview when a URL resolves to a non-media resource instead of storing the resolved HTML or document file.
 - Send and index a generated preview image when a downloaded URL video is too large for Telegram video upload, while still saving the downloaded video locally.
+- Show saved video details when `/detail` replies to a video message.
 - Use random UUIDv7 filenames for downloaded resources while preserving the original file extension.
 - Preserve URL video preview aspect ratios by sending accurate display dimensions and square-pixel Telegram covers/thumbnails.
 - Improve generated video preview clarity by sending higher-resolution Telegram covers while keeping thumbnails within Telegram limits.

--- a/docs/postmortem/2026-06-16-video-detail-command.md
+++ b/docs/postmortem/2026-06-16-video-detail-command.md
@@ -1,0 +1,17 @@
+# Video Detail Command
+
+## What happened
+
+Replying to a saved video message with `/detail` did not show the saved video metadata. The bot treated the replied message as unsupported and answered with the photo-only usage hint instead of looking up the video by its Telegram `file_id`.
+
+## Root cause
+
+The `/detail` command handler only inspected `reply_to_message.photo`. Saved videos are indexed in the same Typesense `photos` collection and already use their video `file_id` as the lookup key, but the command routing never extracted `reply_to_message.video.file_id`.
+
+## Fix applied
+
+The detail command now extracts a media `file_id` from replied photos or videos, then reuses the existing Typesense lookup and detail message rendering. The command description and usage fallback now refer to media instead of only photos.
+
+## What we learned
+
+Commands that read saved media should dispatch on the shared saved-media contract, not on a photo-only Telegram payload shape. Detail, delete, and future media commands should keep photo and video routing explicit when they rely on Telegram reply payloads.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -45,7 +45,7 @@ defmodule SaveIt.Bot do
   command("search", description: "Search photos")
   command("similar", description: "Find similar photos")
   command("delete", description: "Delete message")
-  command("detail", description: "Show photo details")
+  command("detail", description: "Show media details")
 
   command("login", description: "Login")
   command("code", description: "Get code for login")
@@ -170,16 +170,16 @@ defmodule SaveIt.Bot do
   end
 
   def handle({:command, :detail, %{chat: chat, reply_to_message: nil}}, _context) do
-    send_message(chat.id, "reply a photo with /detail command.")
+    send_message(chat.id, "reply a photo or video with /detail command.")
   end
 
   def handle({:command, :detail, %{chat: chat, reply_to_message: reply_to_message}}, _context) do
-    case Map.get(reply_to_message, :photo) do
-      [_ | _] = photos ->
-        handle_detail_command(chat.id, reply_to_message, photos)
+    case detail_media_file_id(reply_to_message) do
+      file_id when is_binary(file_id) ->
+        handle_detail_command(chat.id, reply_to_message, file_id)
 
       _ ->
-        send_message(chat.id, "reply a photo with /detail command.")
+        send_message(chat.id, "reply a photo or video with /detail command.")
     end
   end
 
@@ -1835,17 +1835,22 @@ defmodule SaveIt.Bot do
     delete_message(chat_id, message_id)
   end
 
-  defp handle_detail_command(chat_id, reply_to_message, photos) do
-    file_id = photos |> List.last() |> Map.get(:file_id)
-
+  defp handle_detail_command(chat_id, reply_to_message, file_id) do
     case safe_typesense_get_photo(file_id, chat_id) do
       nil ->
-        send_message(chat_id, "Photo details not found.")
+        send_message(chat_id, "Media details not found.")
 
       photo ->
         send_message(chat_id, detail_message(reply_to_message, photo))
     end
   end
+
+  defp detail_media_file_id(%{photo: [_ | _] = photos}) do
+    photos |> List.last() |> Map.get(:file_id)
+  end
+
+  defp detail_media_file_id(%{video: %{file_id: file_id}}), do: file_id
+  defp detail_media_file_id(_reply_to_message), do: nil
 
   defp detail_message(reply_to_message, photo) do
     [

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -1656,6 +1656,45 @@ defmodule SaveIt.BotTest do
              )
   end
 
+  test "returns details for a replied video", _context do
+    ExGramTestAdapter.backdoor_request(:send_message, %{message_id: 30})
+
+    chat_id = 12_345
+
+    message = %{
+      chat: %{id: chat_id},
+      reply_to_message: %{
+        date: 1_717_200_000,
+        video: %{file_id: "sent-video-file-id"}
+      }
+    }
+
+    assert {:ok, %{message_id: 30}} = Bot.handle({:command, :detail, message}, nil)
+
+    assert_receive {:test_http_request, :get, search_path, ""}
+    assert String.starts_with?(search_path, "/collections/photos/documents/search?")
+    assert search_path =~ "file_id%3A%3Dsent-video-file-id"
+    assert search_path =~ "belongs_to_id%3A%3D12345"
+
+    request_body = sent_message_body()
+
+    assert request_body.chat_id == chat_id
+
+    assert request_body.text ==
+             Enum.join(
+               [
+                 "Message URL: https://t.me/save_it_test_chat/70",
+                 "Original URL: https://www.youtube.com/shorts/clip123",
+                 "Caption: video saved by user",
+                 "Title: Video Page OG Title",
+                 "Description: Video Page OG Description",
+                 "Keywords: video, preview, clip",
+                 "Saved at: 2024-06-01 00:00:00 UTC"
+               ],
+               "\n"
+             )
+  end
+
   test "omits missing values from photo details", _context do
     ExGramTestAdapter.backdoor_request(:send_message, %{message_id: 30})
 
@@ -2250,28 +2289,46 @@ defmodule SaveIt.BotTest do
 
     defp response_for("/collections/photos/documents/search?" <> query, port, _body) do
       document =
-        if query =~ "file_id%3A%3Dold-photo-file-id" do
-          %{
-            "id" => "old-typesense-photo-id",
-            "caption" => "",
-            "file_id" => "old-photo-file-id",
-            "belongs_to_id" => "12345",
-            "inserted_at" => 1_717_200_000
-          }
-        else
-          %{
-            "id" => "typesense-photo-id",
-            "file_id" => "telegram-photo-file-id",
-            "caption" => "saved by user",
-            "title" => "X Page OG Title",
-            "description" => "X Page OG Description",
-            "keywords" => ["x", "twitter", "clip"],
-            "url" => "https://x.com/example/status/1?utm_source=telegram",
-            "download_url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg",
-            "source_message_url" => "https://t.me/save_it_test_chat/20",
-            "belongs_to_id" => "12345",
-            "inserted_at" => 1_717_200_000
-          }
+        cond do
+          query =~ "file_id%3A%3Dold-photo-file-id" ->
+            %{
+              "id" => "old-typesense-photo-id",
+              "caption" => "",
+              "file_id" => "old-photo-file-id",
+              "belongs_to_id" => "12345",
+              "inserted_at" => 1_717_200_000
+            }
+
+          query =~ "file_id%3A%3Dsent-video-file-id" ->
+            %{
+              "id" => "typesense-video-id",
+              "file_id" => "sent-video-file-id",
+              "caption" => "video saved by user",
+              "title" => "Video Page OG Title",
+              "description" => "Video Page OG Description",
+              "keywords" => ["video", "preview", "clip"],
+              "url" => "https://www.youtube.com/shorts/clip123",
+              "download_url" => "http://127.0.0.1:#{port}/downloaded/video.mp4",
+              "source_message_url" => "https://t.me/save_it_test_chat/70",
+              "media_type" => "video",
+              "belongs_to_id" => "12345",
+              "inserted_at" => 1_717_200_000
+            }
+
+          true ->
+            %{
+              "id" => "typesense-photo-id",
+              "file_id" => "telegram-photo-file-id",
+              "caption" => "saved by user",
+              "title" => "X Page OG Title",
+              "description" => "X Page OG Description",
+              "keywords" => ["x", "twitter", "clip"],
+              "url" => "https://x.com/example/status/1?utm_source=telegram",
+              "download_url" => "http://127.0.0.1:#{port}/downloaded/photo.jpg",
+              "source_message_url" => "https://t.me/save_it_test_chat/20",
+              "belongs_to_id" => "12345",
+              "inserted_at" => 1_717_200_000
+            }
         end
 
       json_response(%{


### PR DESCRIPTION
## Summary
- Fix `/detail` command to handle replied videos by resolving `reply_to_message.video.file_id`.
- Reuse existing Typesense detail lookup/rendering for media replies and update user-facing prompts from photo-only to media-aware.
- Keep photo behavior unchanged and add regression test coverage for replied video detail lookup.

## Root cause
- The `/detail` handler only checked `reply_to_message.photo`, so video replies never entered the media detail query path.

## Validation
- `mix test test/bot_test.exs`
- `mix test`

## Impact
- Users can now get saved metadata details for video messages with `/detail`.
- No behavior change for non-media replies; existing photo detail flow remains unchanged.
