### PR TITLE
feat: consolidate bot commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ before the CalVer migration retain their original version labels.
 ### Changed
 
 - Make the save data directory configurable with `SAVE_IT_DATA_DIR`, defaulting to `./data` locally and `/data` in the Docker image, with Docker Compose persisting `/data` on a named volume.
+- Replace the Google Drive bot commands with `/google_drive_login` and `/google_drive_folder`, removing the old `/code`, `/login`, and `/folder` command entries.
+- Merge image-based similar search into `/search`, so text input searches saved photos and photo input finds visually similar media.
 - Store URL Open Graph metadata in dedicated Typesense fields instead of using it as the saved caption, keeping captions limited to user-provided Telegram text.
 - Use local Twitter cookies from `cobalt-cookies.json` to fetch authenticated X metadata for login-restricted posts before falling back to public Open Graph metadata.
 

--- a/docs/specs/001-typesense-saved-content.md
+++ b/docs/specs/001-typesense-saved-content.md
@@ -66,8 +66,8 @@ and future provider-specific extraction can rely on stable field semantics.
   - For Telegram photos and videos, read `message.caption`. If the caption also
     contains the source URL, remove the URL and store the remaining user text.
   - Store an empty string or omit the field when the user did not provide text.
-  - Bot command captions such as `/similar` and `/search` are command input, not
-    saved user captions.
+  - Bot command captions such as `/search` are command input, not saved user
+    captions.
 - `title`:
   - Default to URL metadata `og:title`.
   - Leave unset when no URL metadata exists or the source page has no title.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -43,13 +43,11 @@ defmodule SaveIt.Bot do
   command("start")
 
   command("search", description: "Search photos")
-  command("similar", description: "Find similar photos")
   command("delete", description: "Delete message")
   command("detail", description: "Show photo details")
 
-  command("login", description: "Login")
-  command("code", description: "Get code for login")
-  command("folder", description: "Update Google Drive folder ID")
+  command("google_drive_login", description: "Connect Google Drive")
+  command("google_drive_folder", description: "Set Google Drive folder ID")
 
   command("about", description: "Know more about this bot")
 
@@ -78,73 +76,39 @@ defmodule SaveIt.Bot do
     """)
   end
 
-  def handle({:command, :code, %{chat: chat}}, _context) do
-    case GoogleOAuth2DeviceFlow.get_device_code() do
-      {:ok, response} ->
-        FileHelper.set_google_device_code(chat.id, response["device_code"])
-        # SettingsStore.update_google_device_code(msg.chat.id, response["device_code"])
-
-        send_message(chat.id, """
-        Open the following URL in your browser:
-        #{response["verification_url"]}
-        Enter code: 👇
-        """)
-
-        send_message(chat.id, """
-        #{response["user_code"]}
-        """)
-
-        send_message(chat.id, """
-        Run `/login` after you have logged in.
-        """)
-
-      {:error, _error} ->
-        Logger.error("Failed to get device code")
-        send_message(chat.id, "Failed to get device code")
-    end
-  end
-
-  def handle({:command, :login, %{chat: chat, from: from}}, _context) do
-    case chat.type do
-      "private" ->
+  def handle({:command, :google_drive_login, %{chat: chat} = message}, _context) do
+    case google_drive_login_permission(chat, Map.get(message, :from)) do
+      :ok ->
         login_google(chat)
 
-      x when x == "group" or x == "supergroup" ->
-        {:ok, members} = ExGram.get_chat_administrators(chat.id)
+      {:error, :not_admin} ->
+        send_message(chat.id, "You are not an administrator, you can't connect Google Drive.")
 
-        cond do
-          from.is_bot ->
-            login_google(chat)
-
-          # 其他语言写法 fn member -> member.user.id == from.id end
-          Enum.any?(members, &(&1.user.id == from.id)) ->
-            login_google(chat)
-
-          true ->
-            send_message(chat.id, "You are not an administrator, you can't login.")
-        end
-
-      _ ->
-        send_message(chat.id, "You can't login in this chat.")
+      {:error, :unsupported_chat} ->
+        send_message(chat.id, "You can't connect Google Drive in this chat.")
     end
   end
 
-  def handle({:command, :folder, %{chat: chat, text: text}}, _context) do
-    case text do
-      nil ->
-        send_message(chat.id, "Please provide a folder ID.")
+  def handle({:command, :google_drive_folder, %{chat: chat, text: text}}, _context) do
+    folder_id = normalize_command_text(text)
 
-      "" ->
-        send_message(chat.id, "Please provide a folder ID.")
-
-      _ ->
-        FileHelper.set_google_drive_folder_id(chat.id, text)
-        send_message(chat.id, "Folder ID set successfully.")
+    if folder_id == "" do
+      send_message(chat.id, "Please provide a Google Drive folder ID.")
+    else
+      FileHelper.set_google_drive_folder_id(chat.id, folder_id)
+      send_message(chat.id, "Google Drive folder ID set successfully.")
     end
+  end
+
+  def handle({:command, :search, %{chat: chat, photo: [_ | _] = photos} = message}, _context) do
+    handle_uploaded_photo(message, chat, "/search", photos)
   end
 
   def handle({:command, :search, %{chat: chat, text: nil}}, _context) do
-    send_message(chat.id, "What do you want to search? animal, food, etc.")
+    send_message(
+      chat.id,
+      "What do you want to search? animal, food, etc. Or upload a photo with /search."
+    )
   end
 
   def handle({:command, :search, %{chat: chat, text: text}}, _context)
@@ -159,14 +123,6 @@ defmodule SaveIt.Bot do
         photos = safe_typesense_search_photos(q, belongs_to_id: chat.id)
         answer_photos(chat.id, photos)
     end
-  end
-
-  def handle({:command, :similar, %{chat: chat, photo: nil}}, _context) do
-    send_message(chat.id, "Upload a photo with /similar for finding similar photos.")
-  end
-
-  def handle({:command, :similar, %{chat: chat, photo: [_ | _] = photos} = message}, _context) do
-    handle_uploaded_photo(message, chat, "/similar", photos)
   end
 
   def handle({:command, :detail, %{chat: chat, reply_to_message: nil}}, _context) do
@@ -202,7 +158,7 @@ defmodule SaveIt.Bot do
   end
 
   # caption: nil -> find same photos
-  # caption: contains /similar or /search -> search similar photos; otherwise, find same photos
+  # caption: contains /search -> search similar photos; otherwise, find same photos
   def handle({:message, %{chat: chat, photo: [_ | _] = photos} = message}, _ctx) do
     handle_uploaded_photo(message, chat, Map.get(message, :caption), photos)
   end
@@ -451,7 +407,7 @@ defmodule SaveIt.Bot do
   end
 
   defp search_command_caption?(caption) when is_binary(caption) do
-    String.contains?(caption, ["/similar", "/search"])
+    String.contains?(caption, "/search")
   end
 
   defp search_command_caption?(_caption), do: false
@@ -1800,21 +1756,97 @@ defmodule SaveIt.Bot do
   defp login_google(chat) do
     device_code = FileHelper.get_google_device_code(chat.id)
 
-    case GoogleOAuth2DeviceFlow.exchange_device_code_for_token(device_code) do
-      {:ok, body} ->
-        FileHelper.set_google_access_token(chat.id, body["access_token"])
-        send_message(chat.id, "Successfully logged in!")
+    if present_text?(device_code) do
+      exchange_google_device_code(chat, device_code)
+    else
+      request_google_device_code(chat)
+    end
+  end
 
-      {:error, _error} ->
-        Logger.error("Failed to log in")
+  defp request_google_device_code(chat) do
+    case GoogleOAuth2DeviceFlow.get_device_code() do
+      {:ok, response} ->
+        FileHelper.set_google_device_code(chat.id, response["device_code"])
 
         send_message(chat.id, """
-        Failed to log in.
+        Open the following URL in your browser:
+        #{response["verification_url"] || response["verification_uri"]}
+        Enter code:
+        """)
 
-        Please run `/code` to get a new code, then run `/login` again.
+        send_message(chat.id, """
+        #{response["user_code"]}
+        """)
+
+        send_message(chat.id, """
+        After approving access, run `/google_drive_login` again.
+        """)
+
+      {:error, _error} ->
+        Logger.error("Failed to get Google Drive login code")
+        send_message(chat.id, "Failed to get Google Drive login code.")
+    end
+  end
+
+  defp exchange_google_device_code(chat, device_code) do
+    case GoogleOAuth2DeviceFlow.exchange_device_code_for_token(device_code) do
+      {:ok, %{"access_token" => access_token}} when is_binary(access_token) ->
+        FileHelper.set_google_access_token(chat.id, access_token)
+        FileHelper.set_google_device_code(chat.id, "")
+        send_message(chat.id, "Google Drive connected.")
+
+      {:error, %{body: %{"error" => "authorization_pending"}}} ->
+        send_message(chat.id, """
+        Google authorization is not complete yet.
+
+        Approve access in your browser, then run `/google_drive_login` again.
+        """)
+
+      {:error, %{body: %{"error" => error}}} when error in ["access_denied", "expired_token"] ->
+        FileHelper.set_google_device_code(chat.id, "")
+
+        send_message(chat.id, """
+        Google Drive login code expired or was denied.
+
+        Run `/google_drive_login` to get a new code.
+        """)
+
+      {:error, _error} ->
+        Logger.error("Failed to connect Google Drive")
+
+        send_message(chat.id, """
+        Failed to connect Google Drive.
+
+        Please run `/google_drive_login` again.
         """)
     end
   end
+
+  defp google_drive_login_permission(%{type: "private"}, _from), do: :ok
+
+  defp google_drive_login_permission(%{type: type} = chat, from)
+       when type == "group" or type == "supergroup" do
+    {:ok, members} = ExGram.get_chat_administrators(chat.id)
+
+    cond do
+      Map.get(from || %{}, :is_bot) ->
+        :ok
+
+      Enum.any?(members, &(&1.user.id == Map.get(from || %{}, :id))) ->
+        :ok
+
+      true ->
+        {:error, :not_admin}
+    end
+  end
+
+  defp google_drive_login_permission(_chat, _from), do: {:error, :unsupported_chat}
+
+  defp normalize_command_text(text) when is_binary(text), do: String.trim(text)
+  defp normalize_command_text(_text), do: ""
+
+  defp present_text?(text) when is_binary(text), do: String.trim(text) != ""
+  defp present_text?(_text), do: false
 
   defp handle_delete_command(chat_id, message_id, reply_to_message) do
     case reply_to_message do

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -61,6 +61,98 @@ defmodule SaveIt.BotTest do
     %{base_url: base_url}
   end
 
+  test "declares current bot commands without legacy command entries", _context do
+    command_names = Enum.map(Bot.commands(), & &1[:command])
+
+    assert "search" in command_names
+    refute "similar" in command_names
+    assert "google_drive_login" in command_names
+    assert "google_drive_folder" in command_names
+    refute "login" in command_names
+    refute "code" in command_names
+    refute "folder" in command_names
+  end
+
+  test "google drive login starts the device flow when there is no pending code", _context do
+    configure_google_oauth()
+
+    message = %{
+      chat: %{id: 12_345, type: "private"},
+      from: %{id: 1, is_bot: false}
+    }
+
+    assert {:ok, %{message_id: 10}} = Bot.handle({:command, :google_drive_login, message}, nil)
+
+    assert_receive {:google_oauth_request, request}
+    assert request.method == :post
+    assert request.url.path == "/device/code"
+    assert FileHelper.get_google_device_code(12_345) == "device-code"
+
+    sent_texts = sent_message_texts()
+
+    assert Enum.any?(sent_texts, &String.contains?(&1, "https://www.google.com/device"))
+    assert Enum.any?(sent_texts, &String.contains?(&1, "USER-CODE"))
+    assert Enum.any?(sent_texts, &String.contains?(&1, "/google_drive_login"))
+  end
+
+  test "google drive login exchanges a pending device code", _context do
+    configure_google_oauth()
+    FileHelper.set_google_device_code(12_345, "device-code")
+
+    message = %{
+      chat: %{id: 12_345, type: "private"},
+      from: %{id: 1, is_bot: false}
+    }
+
+    assert {:ok, %{message_id: 10}} = Bot.handle({:command, :google_drive_login, message}, nil)
+
+    assert_receive {:google_oauth_request, request}
+    assert request.method == :post
+    assert request.url.path == "/token"
+    assert FileHelper.get_google_access_token(12_345) == "access-token"
+    assert FileHelper.get_google_device_code(12_345) == ""
+    assert sent_message_body().text =~ "Google Drive connected"
+  end
+
+  test "google drive folder stores the configured folder id", _context do
+    message = %{
+      chat: %{id: 12_345, type: "private"},
+      text: "  drive-folder-id  "
+    }
+
+    assert {:ok, %{message_id: 10}} = Bot.handle({:command, :google_drive_folder, message}, nil)
+
+    assert FileHelper.get_google_drive_folder_id(12_345) == "drive-folder-id"
+    assert sent_message_body().text == "Google Drive folder ID set successfully."
+  end
+
+  test "search command with text searches saved photos", _context do
+    ExGramTestAdapter.backdoor_request(:send_media_group, [
+      %{message_id: 31},
+      %{message_id: 32}
+    ])
+
+    message = %{
+      chat: %{id: 12_345},
+      text: "summer"
+    }
+
+    assert :ok = Bot.handle({:command, :search, message}, nil)
+
+    assert_receive {:test_http_request, :post, "/multi_search", body}
+
+    %{"searches" => [%{"q" => "summer", "filter_by" => "belongs_to_id:=12345"} | _]} =
+      Jason.decode!(body)
+
+    assert Enum.any?(exgram_calls(), fn
+             {:post, :send_media_group, %{chat_id: 12_345, media: media}} ->
+               Enum.map(media, & &1.media) == ["similar-file-1", "similar-file-2"]
+
+             _ ->
+               false
+           end)
+  end
+
   test "about reports private chat status and bot privacy mode", _context do
     ExGramTestAdapter.backdoor_request(:get_me, %{
       id: 9_001,
@@ -1040,7 +1132,7 @@ defmodule SaveIt.BotTest do
            ]
   end
 
-  test "handles /similar command attached to a photo", _context do
+  test "handles /search command attached to a photo as similar image search", _context do
     Application.put_env(:save_it, :telegram_req_options,
       adapter: &__MODULE__.TelegramDownloadAdapter.request/1
     )
@@ -1063,7 +1155,7 @@ defmodule SaveIt.BotTest do
       photo: [%{file_id: "uploaded-photo-file-id"}]
     }
 
-    assert :ok = Bot.handle({:command, :similar, message}, nil)
+    assert :ok = Bot.handle({:command, :search, message}, nil)
 
     calls = exgram_calls()
 
@@ -1094,7 +1186,7 @@ defmodule SaveIt.BotTest do
 
     message = %{
       chat: %{id: 12_345},
-      caption: "/similar",
+      caption: "/search",
       photo: [%{file_id: "uploaded-photo-file-id"}]
     }
 
@@ -1138,7 +1230,7 @@ defmodule SaveIt.BotTest do
 
     message = %{
       chat: %{id: 12_346},
-      caption: "/similar",
+      caption: "/search",
       photo: [%{file_id: "uploaded-photo-file-id"}]
     }
 
@@ -1191,7 +1283,7 @@ defmodule SaveIt.BotTest do
 
     message = %{
       chat: %{id: 12_353},
-      caption: "/similar",
+      caption: "/search",
       photo: [%{file_id: "uploaded-photo-file-id"}]
     }
 
@@ -1227,7 +1319,7 @@ defmodule SaveIt.BotTest do
 
     message = %{
       chat: %{id: 12_351},
-      caption: "/similar",
+      caption: "/search",
       photo: [%{file_id: "uploaded-photo-file-id"}]
     }
 
@@ -1257,7 +1349,7 @@ defmodule SaveIt.BotTest do
 
     message = %{
       chat: %{id: 12_352},
-      caption: "/similar",
+      caption: "/search",
       photo: [%{file_id: "uploaded-photo-file-id"}]
     }
 
@@ -1470,7 +1562,7 @@ defmodule SaveIt.BotTest do
     message = %{
       chat: %{id: chat_id, username: "save_it_directs"},
       message_id: 322,
-      caption: "/similar",
+      caption: "/search",
       video: %{
         file_id: "uploaded-video-file-id",
         file_name: "direct-video.mp4",
@@ -1750,6 +1842,15 @@ defmodule SaveIt.BotTest do
     end)
   end
 
+  defp sent_message_texts do
+    ExGramTestAdapter.get_calls()
+    |> Enum.filter(fn
+      {:post, :send_message, _body} -> true
+      _ -> false
+    end)
+    |> Enum.map(fn {:post, :send_message, body} -> body.text end)
+  end
+
   defp cleanup_cached_folder(cache_key_url) do
     hashed_url = :crypto.hash(:sha256, cache_key_url) |> Base.url_encode64(padding: false)
     url_cache_path = storage_url_path(hashed_url)
@@ -1783,6 +1884,15 @@ defmodule SaveIt.BotTest do
     on_exit(fn ->
       File.rm_rf(settings_dir)
     end)
+  end
+
+  defp configure_google_oauth do
+    Application.put_env(:save_it, :google_oauth_client_id, "client-id")
+    Application.put_env(:save_it, :google_oauth_client_secret, "client-secret")
+
+    Application.put_env(:save_it, :google_oauth_req_options,
+      adapter: &__MODULE__.GoogleOAuthAdapter.request/1
+    )
   end
 
   defp chat_settings_dir(chat_id) do
@@ -2145,6 +2255,27 @@ defmodule SaveIt.BotTest do
     end
   end
 
+  defmodule GoogleOAuthAdapter do
+    def request(%Req.Request{} = request) do
+      send(self(), {:google_oauth_request, request})
+
+      response_body =
+        case request.url.path do
+          "/device/code" ->
+            %{
+              "device_code" => "device-code",
+              "user_code" => "USER-CODE",
+              "verification_url" => "https://www.google.com/device"
+            }
+
+          "/token" ->
+            %{"access_token" => "access-token"}
+        end
+
+      {request, %Req.Response{status: 200, body: response_body}}
+    end
+  end
+
   defmodule TelegramMediaGroupAdapter do
     def request(%Req.Request{} = request) do
       send(self(), {:telegram_media_group_request, request})
@@ -2288,7 +2419,7 @@ defmodule SaveIt.BotTest do
     end
 
     defp response_for("/multi_search", _port, body) do
-      %{"searches" => [%{"filter_by" => filter_by}]} = Jason.decode!(body)
+      %{"searches" => [%{"filter_by" => filter_by} | _]} = Jason.decode!(body)
 
       json_response(%{
         "results" => [


### PR DESCRIPTION
## Summary

- Replace the Google Drive setup commands with `/google_drive_login` and `/google_drive_folder`.
- Merge image-based similar search into `/search`, so text input searches saved photos and photo input finds visually similar media.
- Update the saved-content spec, changelog, and bot tests for the new command model.

## Impact

Users now have fewer bot commands to choose from. `/search` handles both text search and image-based similar search, while Google Drive setup is named explicitly.

## Validation

- `mix test test/bot_test.exs test/save_it/photo_service_test.exs test/save_it/google_oauth2_device_flow_test.exs test/save_it/file_helper_test.exs`
- `mix format --check-formatted lib/save_it/bot.ex test/bot_test.exs docs/specs/001-typesense-saved-content.md CHANGELOG.md`
- `git diff --check`
