### PR TITLE
fix: use resumable Google Drive uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upload Google Drive backups with resumable sessions so large media uploads can recover from timeout responses after Drive has received the file.
+
 ## [2026.6.17] - 2026-06-17
 
 ### Changed

--- a/docs/postmortem/2026-07-01-google-drive-resumable-upload-timeout.md
+++ b/docs/postmortem/2026-07-01-google-drive-resumable-upload-timeout.md
@@ -1,0 +1,17 @@
+# Google Drive Resumable Upload Timeout
+
+## What happened
+
+Google Drive backups could log a `:timeout` error while the file still appeared in the configured Drive folder. The bot uploaded media with a single multipart request, so large files could finish on Drive while the client timed out waiting for the final response.
+
+## Root cause
+
+The Google Drive client used `uploadType=multipart` for every upload. Google Drive documents multipart uploads as a small-file option, while large or interruption-prone uploads should use resumable sessions. Because the app sent metadata and the full media body in one request, a slow large upload had no reliable way to ask Drive whether the timed-out request had actually completed.
+
+## Fix applied
+
+Google Drive uploads now create a resumable upload session with `uploadType=resumable`, then upload media in 8 MB chunks using `Content-Range`. The client continues after `308 Resume Incomplete` and treats final `200` or `201` responses as success. If a chunk request times out, the client queries the same session with an empty status request and resumes from Drive's reported byte range or returns success when Drive reports the file is complete.
+
+## What we learned
+
+Timeout handling needs to match the remote API's upload protocol. For Drive media backups, reducing each request to bounded chunks is only half the fix; the important correctness property is preserving the resumable session so a lost response can be reconciled instead of reported as a failed upload.

--- a/lib/save_it/google_drive.ex
+++ b/lib/save_it/google_drive.ex
@@ -11,7 +11,8 @@ defmodule SaveIt.GoogleDrive do
   require Logger
 
   @google_api_url "https://www.googleapis.com"
-  @upload_type "multipart"
+  @upload_content_type "application/octet-stream"
+  @resumable_upload_chunk_size 8 * 1024 * 1024
 
   def configured?(chat_id) do
     match?({:ok, _folder_id, _access_token}, upload_config(chat_id))
@@ -66,22 +67,10 @@ defmodule SaveIt.GoogleDrive do
       parents: [folder_id]
     }
 
-    boundary = "foo_bar_baz"
-    multipart_body = build_multipart_body(metadata, file_content, boundary)
-
-    headers = [
-      {"Authorization", "Bearer #{access_token}"},
-      {"Content-Type", "multipart/related; boundary=#{boundary}"}
-    ]
-
-    "/upload/drive/v3/files"
-    |> build_request()
-    |> Req.post(
-      body: multipart_body,
-      params: [uploadType: @upload_type],
-      headers: headers
-    )
-    |> handle_response()
+    with {:ok, session_url} <-
+           create_resumable_upload_session(metadata, byte_size(file_content), access_token) do
+      upload_resumable_content(session_url, file_content, access_token)
+    end
   end
 
   def upload_file(chat_id, file_path) do
@@ -97,30 +86,8 @@ defmodule SaveIt.GoogleDrive do
   end
 
   defp upload_file_path(file_path, folder_id, access_token) do
-    metadata = %{
-      name: Path.basename(file_path),
-      parents: [folder_id]
-    }
-
     file_content = File.read!(file_path)
-    boundary = "foo_bar_baz"
-    multipart_body = build_multipart_body(metadata, file_content, boundary)
-
-    headers = [
-      {"Authorization", "Bearer #{access_token}"},
-      {"Content-Type", "multipart/related; boundary=#{boundary}"},
-      {"Content-Length", "*/*"}
-      # {"Content-Length", byte_size(multipart_body) |> Integer.to_string()}
-    ]
-
-    "/upload/drive/v3/files"
-    |> build_request()
-    |> Req.post(
-      body: multipart_body,
-      params: [uploadType: @upload_type],
-      headers: headers
-    )
-    |> handle_response()
+    upload_file(Path.basename(file_path), file_content, folder_id, access_token)
   end
 
   defp upload_config(chat_id) do
@@ -137,40 +104,218 @@ defmodule SaveIt.GoogleDrive do
   defp configured_value?(value) when is_binary(value), do: String.trim(value) != ""
   defp configured_value?(_value), do: false
 
-  defp build_request(path) do
+  defp create_resumable_upload_session(metadata, file_size, access_token) do
+    headers = [
+      {"Authorization", "Bearer #{access_token}"},
+      {"Content-Type", "application/json; charset=UTF-8"},
+      {"X-Upload-Content-Type", @upload_content_type},
+      {"X-Upload-Content-Length", Integer.to_string(file_size)}
+    ]
+
+    "/upload/drive/v3/files"
+    |> build_request()
+    |> Req.post(
+      body: Jason.encode!(metadata),
+      params: [uploadType: "resumable"],
+      headers: headers
+    )
+    |> handle_resumable_session_response()
+  end
+
+  defp upload_resumable_content(session_url, file_content, access_token) do
+    upload_resumable_chunk(session_url, file_content, byte_size(file_content), 0, access_token)
+  end
+
+  defp upload_resumable_chunk(_session_url, _file_content, 0, 0, _access_token) do
+    {:ok, %{}}
+  end
+
+  defp upload_resumable_chunk(session_url, file_content, total_size, offset, access_token)
+       when offset < total_size do
+    chunk_size = min(@resumable_upload_chunk_size, total_size - offset)
+    chunk = :binary.part(file_content, offset, chunk_size)
+    end_offset = offset + chunk_size - 1
+
+    headers = [
+      {"Authorization", "Bearer #{access_token}"},
+      {"Content-Type", @upload_content_type},
+      {"Content-Length", Integer.to_string(chunk_size)},
+      {"Content-Range", "bytes #{offset}-#{end_offset}/#{total_size}"}
+    ]
+
+    session_url
+    |> build_request()
+    |> Req.put(body: chunk, headers: headers)
+    |> handle_resumable_upload_response(
+      session_url,
+      file_content,
+      total_size,
+      offset,
+      access_token
+    )
+  end
+
+  defp build_request(url) do
     req_options =
       :save_it
       |> Application.get_env(:google_drive_req_options, [])
-      |> Keyword.put_new(
-        :base_url,
-        Application.get_env(:save_it, :google_api_url, @google_api_url)
-      )
       |> Keyword.put_new(:retry, false)
-      |> Keyword.put(:url, path)
+      |> maybe_put_base_url(url)
+      |> Keyword.put(:url, url)
       |> Keyword.put_new(:headers, [{"Content-Type", "application/json"}])
 
     Req.new(req_options)
   end
 
-  defp build_multipart_body(metadata, file_content, boundary) do
-    """
-    --#{boundary}
-    Content-Type: application/json; charset=UTF-8
+  defp maybe_put_base_url(req_options, url) do
+    if absolute_url?(url) do
+      Keyword.delete(req_options, :base_url)
+    else
+      Keyword.put_new(
+        req_options,
+        :base_url,
+        Application.get_env(:save_it, :google_api_url, @google_api_url)
+      )
+    end
+  end
 
-    #{Jason.encode!(metadata)}
-    --#{boundary}
-    Content-Type: application/octet-stream
+  defp absolute_url?(url) do
+    url
+    |> URI.parse()
+    |> Map.get(:scheme)
+    |> is_binary()
+  end
 
-    #{file_content}
-    --#{boundary}--
-    """
+  defp handle_resumable_session_response({:ok, %{status: status} = response})
+       when status in [200, 201] do
+    case Req.Response.get_header(response, "location") do
+      [session_url | _] ->
+        {:ok, session_url}
+
+      [] ->
+        Logger.error("Google Drive resumable upload session missing location")
+        {:error, :missing_resumable_upload_location}
+    end
+  end
+
+  defp handle_resumable_session_response(response) do
+    handle_response(response)
+  end
+
+  defp handle_resumable_upload_response(
+         {:ok, %{status: status, body: body}},
+         _session_url,
+         _file_content,
+         _total_size,
+         _next_offset,
+         _access_token
+       )
+       when status in [200, 201] do
+    {:ok, body}
+  end
+
+  defp handle_resumable_upload_response(
+         {:ok, %{status: 308} = response},
+         session_url,
+         file_content,
+         total_size,
+         fallback_offset,
+         access_token
+       ) do
+    offset = next_resumable_offset(response, fallback_offset)
+    upload_resumable_chunk(session_url, file_content, total_size, offset, access_token)
+  end
+
+  defp handle_resumable_upload_response(
+         {:error, %Req.TransportError{}},
+         session_url,
+         file_content,
+         total_size,
+         _next_offset,
+         access_token
+       ) do
+    session_url
+    |> request_resumable_upload_status(total_size, access_token)
+    |> handle_resumable_status_response(session_url, file_content, total_size, access_token)
+  end
+
+  defp handle_resumable_upload_response(
+         response,
+         _session_url,
+         _file_content,
+         _total_size,
+         _next_offset,
+         _access_token
+       ) do
+    handle_response(response)
+  end
+
+  defp request_resumable_upload_status(session_url, total_size, access_token) do
+    headers = [
+      {"Authorization", "Bearer #{access_token}"},
+      {"Content-Length", "0"},
+      {"Content-Range", "*/#{total_size}"}
+    ]
+
+    session_url
+    |> build_request()
+    |> Req.put(body: "", headers: headers)
+  end
+
+  defp handle_resumable_status_response(
+         {:ok, %{status: status, body: body}},
+         _session_url,
+         _file_content,
+         _total_size,
+         _access_token
+       )
+       when status in [200, 201] do
+    {:ok, body}
+  end
+
+  defp handle_resumable_status_response(
+         {:ok, %{status: 308} = response},
+         session_url,
+         file_content,
+         total_size,
+         access_token
+       ) do
+    offset = next_resumable_offset(response, 0)
+    upload_resumable_chunk(session_url, file_content, total_size, offset, access_token)
+  end
+
+  defp handle_resumable_status_response(
+         response,
+         _session_url,
+         _file_content,
+         _total_size,
+         _access_token
+       ) do
+    handle_response(response)
+  end
+
+  defp next_resumable_offset(response, fallback_offset) do
+    case Req.Response.get_header(response, "range") do
+      [range | _] ->
+        range
+        |> String.split("-")
+        |> List.last()
+        |> Integer.parse()
+        |> case do
+          {last_byte, ""} -> last_byte + 1
+          _ -> fallback_offset
+        end
+
+      [] ->
+        fallback_offset
+    end
   end
 
   defp handle_response({:ok, %{status: 200, body: %{"files" => files}}}) do
     {:ok, files}
   end
 
-  defp handle_response({:ok, %{status: 200, body: body}}) do
+  defp handle_response({:ok, %{status: status, body: body}}) when status in [200, 201] do
     {:ok, body}
   end
 

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -1452,15 +1452,7 @@ defmodule SaveIt.BotTest do
     refute Map.has_key?(document, "url")
     refute Map.has_key?(document, "download_url")
 
-    assert_receive {:google_drive_upload_request, drive_env}
-
-    assert URI.to_string(drive_env.url) ==
-             "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart"
-
-    assert drive_env.headers["authorization"] == ["Bearer test-drive-token"]
-    drive_body = IO.iodata_to_binary(drive_env.body)
-    assert binary_contains?(drive_body, ~s("name":"direct-photo.jpg"))
-    assert binary_contains?(drive_body, "test-drive-folder")
+    assert_google_drive_resumable_upload("direct-photo.jpg", test_jpeg())
     assert File.read(stored_file_path) == {:ok, test_jpeg()}
   end
 
@@ -1624,12 +1616,7 @@ defmodule SaveIt.BotTest do
     refute Map.has_key?(document, "source_message_id")
     assert document["source_message_url"] == "https://t.me/save_it_directs/322"
 
-    assert_receive {:google_drive_upload_request, drive_env}
-    assert drive_env.headers["authorization"] == ["Bearer test-drive-token"]
-    drive_body = IO.iodata_to_binary(drive_env.body)
-    assert binary_contains?(drive_body, ~s("name":"direct-video.mp4"))
-    assert binary_contains?(drive_body, "test-drive-folder")
-    assert binary_contains?(drive_body, test_mp4())
+    assert_google_drive_resumable_upload("direct-video.mp4", test_mp4())
     assert File.read(stored_file_path) == {:ok, test_mp4()}
 
     assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
@@ -1978,6 +1965,40 @@ defmodule SaveIt.BotTest do
     Path.join([FileHelper.data_dir(), "settings", to_string(chat_id)])
   end
 
+  defp assert_google_drive_resumable_upload(file_name, file_content) do
+    assert_receive {:google_drive_upload_request, create_session_request}
+
+    assert URI.to_string(create_session_request.url) ==
+             "https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable"
+
+    assert create_session_request.headers["authorization"] == ["Bearer test-drive-token"]
+    assert create_session_request.headers["x-upload-content-type"] == ["application/octet-stream"]
+
+    assert create_session_request.headers["x-upload-content-length"] == [
+             Integer.to_string(byte_size(file_content))
+           ]
+
+    assert Jason.decode!(IO.iodata_to_binary(create_session_request.body)) == %{
+             "name" => file_name,
+             "parents" => ["test-drive-folder"]
+           }
+
+    assert_receive {:google_drive_upload_request, upload_request}
+    assert URI.to_string(upload_request.url) == "https://uploads.example/session"
+    assert upload_request.headers["authorization"] == ["Bearer test-drive-token"]
+    assert upload_request.headers["content-type"] == ["application/octet-stream"]
+
+    assert upload_request.headers["content-length"] == [
+             Integer.to_string(byte_size(file_content))
+           ]
+
+    assert upload_request.headers["content-range"] == [
+             "bytes 0-#{byte_size(file_content) - 1}/#{byte_size(file_content)}"
+           ]
+
+    assert IO.iodata_to_binary(upload_request.body) == file_content
+  end
+
   def test_jpeg do
     <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70>>
   end
@@ -1996,10 +2017,6 @@ defmodule SaveIt.BotTest do
 
   def test_mp4 do
     <<0, 0, 0, 24, 102, 116, 121, 112, 109, 112, 52, 50>>
-  end
-
-  defp binary_contains?(binary, pattern) do
-    :binary.match(binary, pattern) != :nomatch
   end
 
   defp multipart_field(multipart, name) do
@@ -2365,7 +2382,20 @@ defmodule SaveIt.BotTest do
     def request(%Req.Request{} = request) do
       send(self(), {:google_drive_upload_request, request})
 
-      {request, %Req.Response{status: 200, body: %{"id" => "drive-file-id"}}}
+      response =
+        case {request.method, request.url.path, request.url.query} do
+          {:post, "/upload/drive/v3/files", "uploadType=resumable"} ->
+            Req.Response.new(
+              status: 200,
+              headers: [{"location", "https://uploads.example/session"}],
+              body: ""
+            )
+
+          {:put, "/session", nil} ->
+            %Req.Response{status: 201, body: %{"id" => "drive-file-id"}}
+        end
+
+      {request, response}
     end
   end
 

--- a/test/save_it/google_drive_test.exs
+++ b/test/save_it/google_drive_test.exs
@@ -1,0 +1,179 @@
+defmodule SaveIt.GoogleDriveTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :tmp_dir
+
+  alias SaveIt.FileHelper
+  alias SaveIt.GoogleDrive
+
+  @chunk_size 8 * 1024 * 1024
+
+  setup %{tmp_dir: tmp_dir} do
+    previous_save_it = Application.get_all_env(:save_it)
+
+    Application.put_env(:save_it, :data_dir, tmp_dir)
+    Application.put_env(:save_it, :google_api_url, "https://www.googleapis.com")
+    Application.put_env(:save_it, :test_pid, self())
+
+    Application.put_env(:save_it, :google_drive_req_options,
+      adapter: &__MODULE__.request_adapter/1
+    )
+
+    on_exit(fn ->
+      restore_env(:save_it, previous_save_it)
+    end)
+
+    :ok
+  end
+
+  test "uploads file content through a resumable session in chunks" do
+    chat_id = 12_345
+    file_content = :binary.copy("a", @chunk_size) <> "end"
+
+    configure_google_drive(chat_id)
+
+    assert {:ok, %{"id" => "drive-file-id"}} =
+             GoogleDrive.upload_file_content(chat_id, file_content, "large-video.mp4")
+
+    total_size = byte_size(file_content)
+
+    assert_receive {:google_drive_request, create_session_request}
+    assert create_session_request.method == :post
+
+    assert URI.to_string(create_session_request.url) ==
+             "https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable"
+
+    assert create_session_request.headers["authorization"] == ["Bearer test-drive-token"]
+    assert create_session_request.headers["content-type"] == ["application/json; charset=UTF-8"]
+    assert create_session_request.headers["x-upload-content-type"] == ["application/octet-stream"]
+
+    assert create_session_request.headers["x-upload-content-length"] == [
+             Integer.to_string(total_size)
+           ]
+
+    assert Jason.decode!(IO.iodata_to_binary(create_session_request.body)) == %{
+             "name" => "large-video.mp4",
+             "parents" => ["test-drive-folder"]
+           }
+
+    assert_receive {:google_drive_request, first_chunk_request}
+    assert first_chunk_request.method == :put
+    assert URI.to_string(first_chunk_request.url) == "https://uploads.example/session"
+    assert first_chunk_request.headers["authorization"] == ["Bearer test-drive-token"]
+    assert first_chunk_request.headers["content-type"] == ["application/octet-stream"]
+    assert first_chunk_request.headers["content-length"] == [Integer.to_string(@chunk_size)]
+    assert first_chunk_request.headers["content-range"] == ["bytes 0-8388607/#{total_size}"]
+
+    assert IO.iodata_to_binary(first_chunk_request.body) ==
+             :binary.part(file_content, 0, @chunk_size)
+
+    assert_receive {:google_drive_request, final_chunk_request}
+    assert final_chunk_request.method == :put
+    assert URI.to_string(final_chunk_request.url) == "https://uploads.example/session"
+    assert final_chunk_request.headers["authorization"] == ["Bearer test-drive-token"]
+    assert final_chunk_request.headers["content-type"] == ["application/octet-stream"]
+    assert final_chunk_request.headers["content-length"] == ["3"]
+    assert final_chunk_request.headers["content-range"] == ["bytes 8388608-8388610/#{total_size}"]
+    assert IO.iodata_to_binary(final_chunk_request.body) == "end"
+  end
+
+  test "checks resumable upload status after a timed-out chunk" do
+    chat_id = 12_346
+    file_content = "file content"
+
+    Application.put_env(:save_it, :google_drive_req_options,
+      adapter: &__MODULE__.timeout_after_upload_adapter/1
+    )
+
+    configure_google_drive(chat_id)
+
+    assert {:ok, %{"id" => "drive-file-id"}} =
+             GoogleDrive.upload_file_content(chat_id, file_content, "timeout-video.mp4")
+
+    assert_receive {:google_drive_request, create_session_request}
+    assert create_session_request.method == :post
+
+    assert_receive {:google_drive_request, upload_request}
+    assert upload_request.method == :put
+    assert upload_request.headers["content-range"] == ["bytes 0-11/12"]
+
+    assert_receive {:google_drive_request, status_request}
+    assert status_request.method == :put
+    assert URI.to_string(status_request.url) == "https://uploads.example/session"
+    assert status_request.headers["authorization"] == ["Bearer test-drive-token"]
+    assert status_request.headers["content-length"] == ["0"]
+    assert status_request.headers["content-range"] == ["*/12"]
+    assert IO.iodata_to_binary(status_request.body) == ""
+  end
+
+  def request_adapter(%Req.Request{} = request) do
+    send(Application.fetch_env!(:save_it, :test_pid), {:google_drive_request, request})
+
+    response =
+      case {request.method, request.url.path, request.url.query} do
+        {:post, "/upload/drive/v3/files", "uploadType=resumable"} ->
+          Req.Response.new(
+            status: 200,
+            headers: [{"location", "https://uploads.example/session"}],
+            body: ""
+          )
+
+        {:put, "/session", nil} ->
+          handle_upload_chunk(request)
+      end
+
+    {request, response}
+  end
+
+  defp handle_upload_chunk(request) do
+    case request.headers["content-range"] do
+      ["bytes 0-8388607/8388611"] ->
+        Req.Response.new(
+          status: 308,
+          headers: [{"range", "bytes=0-8388607"}],
+          body: ""
+        )
+
+      ["bytes 8388608-8388610/8388611"] ->
+        %Req.Response{status: 201, body: %{"id" => "drive-file-id"}}
+    end
+  end
+
+  def timeout_after_upload_adapter(%Req.Request{} = request) do
+    send(Application.fetch_env!(:save_it, :test_pid), {:google_drive_request, request})
+
+    response =
+      case {request.method, request.url.path, request.url.query, request.headers["content-range"]} do
+        {:post, "/upload/drive/v3/files", "uploadType=resumable", _content_range} ->
+          Req.Response.new(
+            status: 200,
+            headers: [{"location", "https://uploads.example/session"}],
+            body: ""
+          )
+
+        {:put, "/session", nil, ["bytes 0-11/12"]} ->
+          Req.TransportError.exception(reason: :timeout)
+
+        {:put, "/session", nil, ["*/12"]} ->
+          %Req.Response{status: 201, body: %{"id" => "drive-file-id"}}
+      end
+
+    {request, response}
+  end
+
+  defp configure_google_drive(chat_id) do
+    FileHelper.set_google_access_token(chat_id, "test-drive-token")
+    FileHelper.set_google_drive_folder_id(chat_id, "test-drive-folder")
+  end
+
+  defp restore_env(app, env) do
+    app
+    |> Application.get_all_env()
+    |> Keyword.keys()
+    |> Enum.each(&Application.delete_env(app, &1))
+
+    Enum.each(env, fn {key, value} ->
+      Application.put_env(app, key, value)
+    end)
+  end
+end


### PR DESCRIPTION
## Summary

- Replace Google Drive multipart uploads with resumable upload sessions.
- Upload media in 8 MB chunks and continue after `308 Resume Incomplete` responses.
- Query the resumable session after transport timeouts so uploads that completed on Drive are not reported as failures.
- Add regression coverage for chunking and timeout reconciliation, plus a postmortem and changelog entry.

## Root Cause

Google Drive backups used `uploadType=multipart` for every file. Large media could finish uploading on Drive while the client timed out waiting for the final response, leaving the bot to log a failure even though the file existed in Drive.

## Validation

- `mix test` — 109 tests, 0 failures
- `mix checks` — passed successfully
- `git diff --check`

Closes #64
