### PR TITLE
fix: recover Google Drive OAuth login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Fixed
+
+- Make Google Drive backup outcomes visible in runtime logs when uploads complete, fail, or are skipped because Drive is not configured.
+- Keep Google Drive login recoverable when Google rejects OAuth client configuration by clearing stuck pending device codes and showing actionable setup guidance.
+
 ## [2026.7.2-rc.1] - 2026-07-02
 
 ### Fixed

--- a/docs/postmortem/2026-07-02-google-drive-login-invalid-client.md
+++ b/docs/postmortem/2026-07-02-google-drive-login-invalid-client.md
@@ -1,0 +1,21 @@
+# Google Drive Login Invalid Client
+
+## What happened
+
+Users could get stuck after approving a Google Drive device login code. Re-running `/google_drive_login` kept returning "Failed to connect Google Drive" while runtime logs only showed a Google OAuth `401`.
+
+## Root cause
+
+The bot treated all Google OAuth token exchange failures as generic failures. When Google returned `invalid_client`, the saved pending device code stayed on disk, so subsequent `/google_drive_login` attempts retried the same failing token exchange instead of starting a fresh device flow.
+
+The OAuth client module also accepted missing or blank runtime OAuth configuration, allowing the bot to start a device flow that could not complete successfully.
+
+## Fix applied
+
+Google OAuth configuration is now validated before any device flow request. Missing or blank `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` values return a structured error and produce an actionable Telegram message.
+
+When Google returns `invalid_client`, the bot now clears the pending device code and tells the operator to verify that the configured client ID and secret belong to a Google OAuth client with the "TVs and Limited Input devices" application type.
+
+## What we learned
+
+OAuth device flow errors need separate handling because some failures are recoverable user-state problems and others are operator configuration problems. Keeping a stale pending device code after `invalid_client` hides the path back to a clean login attempt.

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -1782,6 +1782,14 @@ defmodule SaveIt.Bot do
         After approving access, run `/google_drive_login` again.
         """)
 
+      {:error, {:missing_config, key}} ->
+        Logger.error("Google Drive login config missing", key: key)
+        send_message(chat.id, missing_google_oauth_config_message(key))
+
+      {:error, %{body: %{"error" => "invalid_client"}}} ->
+        Logger.error("Google Drive login config invalid")
+        send_message(chat.id, invalid_google_oauth_client_message())
+
       {:error, _error} ->
         Logger.error("Failed to get Google Drive login code")
         send_message(chat.id, "Failed to get Google Drive login code.")
@@ -1802,6 +1810,15 @@ defmodule SaveIt.Bot do
         Approve access in your browser, then run `/google_drive_login` again.
         """)
 
+      {:error, {:missing_config, key}} ->
+        Logger.error("Google Drive login config missing", key: key)
+        send_message(chat.id, missing_google_oauth_config_message(key))
+
+      {:error, %{body: %{"error" => "invalid_client"}}} ->
+        FileHelper.set_google_device_code(chat.id, "")
+        Logger.error("Google Drive login config invalid")
+        send_message(chat.id, invalid_google_oauth_client_message())
+
       {:error, %{body: %{"error" => error}}} when error in ["access_denied", "expired_token"] ->
         FileHelper.set_google_device_code(chat.id, "")
 
@@ -1820,6 +1837,32 @@ defmodule SaveIt.Bot do
         Please run `/google_drive_login` again.
         """)
     end
+  end
+
+  defp missing_google_oauth_config_message(:google_oauth_client_id) do
+    """
+    Google Drive login is not configured.
+
+    Ask the bot operator to set GOOGLE_OAUTH_CLIENT_ID, then run `/google_drive_login` again.
+    """
+  end
+
+  defp missing_google_oauth_config_message(:google_oauth_client_secret) do
+    """
+    Google Drive login is not configured.
+
+    Ask the bot operator to set GOOGLE_OAUTH_CLIENT_SECRET, then run `/google_drive_login` again.
+    """
+  end
+
+  defp invalid_google_oauth_client_message do
+    """
+    Google Drive login configuration is invalid.
+
+    Ask the bot operator to verify GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET match a Google OAuth client whose application type is TVs and Limited Input devices.
+
+    After fixing the configuration, run `/google_drive_login` again.
+    """
   end
 
   defp google_drive_login_permission(%{type: "private"}, _from), do: :ok

--- a/lib/save_it/google_oauth2_device_flow.ex
+++ b/lib/save_it/google_oauth2_device_flow.ex
@@ -5,21 +5,26 @@ defmodule SaveIt.GoogleOAuth2DeviceFlow do
   @google_oauth_api_url "https://oauth2.googleapis.com"
 
   def get_device_code do
-    {client_id, _} = get_env()
+    with {:ok, {client_id, _client_secret}} <- get_env() do
+      body = %{
+        client_id: client_id,
+        scope: "https://www.googleapis.com/auth/drive.file"
+      }
 
-    body = %{
-      client_id: client_id,
-      scope: "https://www.googleapis.com/auth/drive.file"
-    }
-
-    "/device/code"
-    |> build_request()
-    |> Req.post(form: body)
-    |> handle_response()
+      "/device/code"
+      |> build_request()
+      |> Req.post(form: body)
+      |> handle_response()
+    end
   end
 
   defp handle_response({:ok, %{status: 200, body: body}}) do
     {:ok, body}
+  end
+
+  defp handle_response({:ok, %{status: status, body: %{"error" => error} = body}}) do
+    Logger.warning("Google OAuth request failed error=#{error}", status: status)
+    {:error, %{status: status, body: body}}
   end
 
   defp handle_response({:ok, %{status: status, body: body}}) do
@@ -33,26 +38,42 @@ defmodule SaveIt.GoogleOAuth2DeviceFlow do
   end
 
   def exchange_device_code_for_token(device_code) do
-    {client_id, client_secret} = get_env()
+    with {:ok, {client_id, client_secret}} <- get_env() do
+      body = %{
+        client_id: client_id,
+        client_secret: client_secret,
+        device_code: device_code,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code"
+      }
 
-    body = %{
-      client_id: client_id,
-      client_secret: client_secret,
-      device_code: device_code,
-      grant_type: "urn:ietf:params:oauth:grant-type:device_code"
-    }
-
-    "/token"
-    |> build_request()
-    |> Req.post(form: body)
-    |> handle_response()
+      "/token"
+      |> build_request()
+      |> Req.post(form: body)
+      |> handle_response()
+    end
   end
 
   defp get_env do
-    client_id = Application.fetch_env!(:save_it, :google_oauth_client_id)
-    client_secret = Application.fetch_env!(:save_it, :google_oauth_client_secret)
+    with {:ok, client_id} <- fetch_config(:google_oauth_client_id),
+         {:ok, client_secret} <- fetch_config(:google_oauth_client_secret) do
+      {:ok, {client_id, client_secret}}
+    end
+  end
 
-    {client_id, client_secret}
+  defp fetch_config(key) do
+    case Application.fetch_env(:save_it, key) do
+      {:ok, value} when is_binary(value) ->
+        value = String.trim(value)
+
+        if value == "" do
+          {:error, {:missing_config, key}}
+        else
+          {:ok, value}
+        end
+
+      _ ->
+        {:error, {:missing_config, key}}
+    end
   end
 
   defp build_request(path) do

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -114,6 +114,29 @@ defmodule SaveIt.BotTest do
     assert sent_message_body().text =~ "Google Drive connected"
   end
 
+  test "google drive login clears the pending device code when OAuth client is invalid",
+       _context do
+    configure_invalid_google_oauth_client()
+    FileHelper.set_google_device_code(12_345, "device-code")
+
+    message = %{
+      chat: %{id: 12_345, type: "private"},
+      from: %{id: 1, is_bot: false}
+    }
+
+    assert {:ok, %{message_id: 10}} = Bot.handle({:command, :google_drive_login, message}, nil)
+
+    assert_receive {:google_oauth_request, request}
+    assert request.method == :post
+    assert request.url.path == "/token"
+    assert FileHelper.get_google_device_code(12_345) == ""
+
+    sent_text = sent_message_body().text
+    assert sent_text =~ "Google Drive login configuration is invalid"
+    assert sent_text =~ "TVs and Limited Input devices"
+    assert sent_text =~ "/google_drive_login"
+  end
+
   test "google drive folder stores the configured folder id", _context do
     message = %{
       chat: %{id: 12_345, type: "private"},
@@ -1961,6 +1984,15 @@ defmodule SaveIt.BotTest do
     )
   end
 
+  defp configure_invalid_google_oauth_client do
+    Application.put_env(:save_it, :google_oauth_client_id, "client-id")
+    Application.put_env(:save_it, :google_oauth_client_secret, "client-secret")
+
+    Application.put_env(:save_it, :google_oauth_req_options,
+      adapter: &__MODULE__.InvalidGoogleOAuthClientAdapter.request/1
+    )
+  end
+
   defp chat_settings_dir(chat_id) do
     Path.join([FileHelper.data_dir(), "settings", to_string(chat_id)])
   end
@@ -2417,6 +2449,21 @@ defmodule SaveIt.BotTest do
         end
 
       {request, %Req.Response{status: 200, body: response_body}}
+    end
+  end
+
+  defmodule InvalidGoogleOAuthClientAdapter do
+    def request(%Req.Request{} = request) do
+      send(self(), {:google_oauth_request, request})
+
+      {request,
+       %Req.Response{
+         status: 401,
+         body: %{
+           "error" => "invalid_client",
+           "error_description" => "The OAuth client was not found."
+         }
+       }}
     end
   end
 

--- a/test/save_it/google_oauth2_device_flow_test.exs
+++ b/test/save_it/google_oauth2_device_flow_test.exs
@@ -35,6 +35,15 @@ defmodule SaveIt.GoogleOAuth2DeviceFlowTest do
     assert body =~ "scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.file"
   end
 
+  test "does not request a device code when OAuth config is incomplete" do
+    Application.put_env(:save_it, :google_oauth_client_secret, "")
+
+    assert {:error, {:missing_config, :google_oauth_client_secret}} =
+             GoogleOAuth2DeviceFlow.get_device_code()
+
+    refute_receive {:google_oauth_request, _request}
+  end
+
   test "exchanges a device code with a Req form request" do
     assert {:ok, %{"access_token" => "access-token"}} =
              GoogleOAuth2DeviceFlow.exchange_device_code_for_token("device-code")


### PR DESCRIPTION
## Summary

- Validate Google OAuth client configuration before starting the Google Drive device flow.
- Clear a stuck pending device code when Google returns `invalid_client`, so `/google_drive_login` can start cleanly after the operator fixes configuration.
- Surface actionable Telegram guidance and log the Google OAuth error code inline.
- Add a postmortem and changelog entry for the login recovery fix.

## Root cause

Google OAuth `invalid_client` responses during token exchange were handled as generic failures. The bot kept the pending device code on disk, so later `/google_drive_login` attempts retried the same failing exchange instead of recovering. Missing or blank OAuth env vars could also start a device flow that could not complete.

## Validation

- `mix format`
- `mix test test/save_it/google_oauth2_device_flow_test.exs test/bot_test.exs --trace --seed 0`
- `mix compile --warnings-as-errors`

## Notes

Unrelated local Google Drive upload visibility changes were left uncommitted and are not part of this PR.
