### PR TITLE
fix: log Google Drive upload outcomes

### DIFF
--- a/docs/postmortem/2026-07-02-google-drive-upload-visibility.md
+++ b/docs/postmortem/2026-07-02-google-drive-upload-visibility.md
@@ -1,0 +1,23 @@
+# Google Drive Upload Visibility
+
+## What happened
+
+A URL download completed and logged `resource_created source=url_download`, but the media did not appear in the expected Google Drive folder. Runtime logs did not show whether the Drive backup was attempted, skipped, completed, or failed.
+
+## Root cause
+
+The URL download finalization path called `GoogleDrive.upload_file_content/3`, but the Google Drive client returned `{:ok, :skipped}` silently when a chat did not have both an access token and folder ID configured. Successful uploads were also silent. As a result, `resource_created` confirmed only local/resource creation, not the Google Drive backup outcome.
+
+## Fix applied
+
+Google Drive uploads now log a concise outcome at the integration boundary:
+
+- `google_drive_upload_completed` when a file upload finishes.
+- `google_drive_upload_failed` with status or reason when an upload fails.
+- `google_drive_upload_skipped reason=not_configured` when a chat has no complete Drive configuration.
+
+Tests now cover successful upload logging and skipped-upload logging.
+
+## What we learned
+
+Optional integrations still need clear runtime visibility at the point where work is skipped or completed. Resource creation and external backup are separate outcomes, so their logs should not imply each other.

--- a/lib/save_it/google_drive.ex
+++ b/lib/save_it/google_drive.ex
@@ -44,6 +44,8 @@ defmodule SaveIt.GoogleDrive do
         upload_file(file_name, file_content, folder_id, access_token)
 
       :not_configured ->
+        Logger.info("google_drive_upload_skipped reason=not_configured file_name=#{file_name}")
+
         {:ok, :skipped}
     end
   end
@@ -57,6 +59,10 @@ defmodule SaveIt.GoogleDrive do
         end)
 
       :not_configured ->
+        Logger.info(
+          "google_drive_upload_skipped reason=not_configured file_count=#{length(files)}"
+        )
+
         {:ok, :skipped}
     end
   end
@@ -67,11 +73,32 @@ defmodule SaveIt.GoogleDrive do
       parents: [folder_id]
     }
 
-    with {:ok, session_url} <-
-           create_resumable_upload_session(metadata, byte_size(file_content), access_token) do
-      upload_resumable_content(session_url, file_content, access_token)
+    result =
+      with {:ok, session_url} <-
+             create_resumable_upload_session(metadata, byte_size(file_content), access_token) do
+        upload_resumable_content(session_url, file_content, access_token)
+      end
+
+    case result do
+      {:ok, _body} ->
+        Logger.info("google_drive_upload_completed file_name=#{file_name}")
+
+      {:error, reason} ->
+        Logger.warning(
+          "google_drive_upload_failed file_name=#{file_name} #{upload_failure_details(reason)}"
+        )
     end
+
+    result
   end
+
+  defp upload_failure_details(%{status: status}), do: "status=#{status}"
+
+  defp upload_failure_details(%Req.TransportError{reason: reason}),
+    do: "reason=#{inspect(reason)}"
+
+  defp upload_failure_details(reason) when is_atom(reason), do: "reason=#{reason}"
+  defp upload_failure_details(_reason), do: "reason=unknown"
 
   def upload_file(chat_id, file_path) do
     # settings = SettingsStore.get(chat_id)
@@ -81,6 +108,10 @@ defmodule SaveIt.GoogleDrive do
         upload_file_path(file_path, folder_id, access_token)
 
       :not_configured ->
+        Logger.info(
+          "google_drive_upload_skipped reason=not_configured file_name=#{Path.basename(file_path)}"
+        )
+
         {:ok, :skipped}
     end
   end

--- a/test/save_it/google_drive_test.exs
+++ b/test/save_it/google_drive_test.exs
@@ -1,6 +1,8 @@
 defmodule SaveIt.GoogleDriveTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   @moduletag :tmp_dir
 
   alias SaveIt.FileHelper
@@ -32,8 +34,13 @@ defmodule SaveIt.GoogleDriveTest do
 
     configure_google_drive(chat_id)
 
-    assert {:ok, %{"id" => "drive-file-id"}} =
-             GoogleDrive.upload_file_content(chat_id, file_content, "large-video.mp4")
+    log =
+      capture_log(fn ->
+        assert {:ok, %{"id" => "drive-file-id"}} =
+                 GoogleDrive.upload_file_content(chat_id, file_content, "large-video.mp4")
+      end)
+
+    assert log =~ "google_drive_upload_completed file_name=large-video.mp4"
 
     total_size = byte_size(file_content)
 
@@ -75,6 +82,17 @@ defmodule SaveIt.GoogleDriveTest do
     assert final_chunk_request.headers["content-length"] == ["3"]
     assert final_chunk_request.headers["content-range"] == ["bytes 8388608-8388610/#{total_size}"]
     assert IO.iodata_to_binary(final_chunk_request.body) == "end"
+  end
+
+  test "logs when file content upload is skipped because Google Drive is not configured" do
+    log =
+      capture_log(fn ->
+        assert {:ok, :skipped} =
+                 GoogleDrive.upload_file_content(12_345, "file content", "missing-config.mp4")
+      end)
+
+    assert log =~ "google_drive_upload_skipped reason=not_configured file_name=missing-config.mp4"
+    refute_receive {:google_drive_request, _request}
   end
 
   test "checks resumable upload status after a timed-out chunk" do


### PR DESCRIPTION
## Summary

- Log Google Drive backup outcomes when uploads complete, fail, or are skipped because Drive is not configured.
- Add regression coverage for completed and skipped upload logs.
- Record the missing-upload-visibility incident in a postmortem.

## Root Cause

`resource_created source=url_download` only confirmed local resource creation. The Google Drive client silently returned `{:ok, :skipped}` when a chat lacked complete Drive configuration, and successful uploads were also silent.

## Test Plan

- `mix format --check-formatted lib/save_it/google_drive.ex test/save_it/google_drive_test.exs`
- `mix test test/save_it/google_drive_test.exs test/bot_test.exs`
