### PR TITLE
test: simplify logger config assertions

### DIFF
--- a/test/logger_config_test.exs
+++ b/test/logger_config_test.exs
@@ -10,7 +10,6 @@ defmodule SaveIt.LoggerConfigTest do
 
     logger_config = Application.fetch_env!(:logger, :default_formatter)
 
-    assert logger_config[:metadata] == [:status, :file_id, :kind, :key]
     assert logger_config[:colors][:info] == :normal
     assert logger_config[:colors][:warning] == :yellow
     assert logger_config[:colors][:error] == :red


### PR DESCRIPTION
## Summary
- Remove the exact Logger formatter metadata list assertion from `LoggerConfigTest`.
- Keep the runtime logger color behavior checks that matter for user-visible log output.

## Rationale
The exact metadata list assertion made the test brittle. Credo already guards missing configured Logger metadata keys, while this test should stay focused on visible logger behavior.

## Verification
- `mix test test/logger_config_test.exs`
- `mix test`
- `mix credo --strict`
- `mix format --check-formatted`
