### PR TITLE
fix: handle Telegram rate limits and pending updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Fixed
+
+- Process all pending Telegram URL messages after the bot restarts instead of keeping only the latest offline message.
+
 ## [2026.7.6-rc.1] - 2026-07-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+### Fixed
+
+- Automatically retry URL saves once when Telegram rate limits the initial bot response, and tell users when the retry is scheduled.
+
 ## [2026.7.2] - 2026-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ before the CalVer migration retain their original version labels.
 
 ## [Unreleased]
 
+## [2026.7.6-rc.1] - 2026-07-06
+
 ### Fixed
 
 - Automatically retry URL saves once when Telegram rate limits the initial bot response, and tell users when the retry is scheduled.

--- a/docs/postmortem/2026-07-06-telegram-pending-updates.md
+++ b/docs/postmortem/2026-07-06-telegram-pending-updates.md
@@ -1,0 +1,21 @@
+# Telegram Pending Updates Dropped on Startup
+
+## What happened
+
+When the bot was offline and a user sent multiple URL messages, restarting the bot processed only the newest pending message. Older pending URL messages disappeared from the Telegram update queue and were never saved.
+
+## Root cause
+
+`save_it` used ExGram's default polling worker. On startup that worker initialized its first `getUpdates` request with `offset: -1`. Telegram Bot API treats a negative offset as a request for updates from the end of the queue; `-1` returns only the latest pending update and forgets all previous updates.
+
+This was not caused by a recent Telegram Bot API behavior change. The current Bot API still documents that omitting `offset` returns the earliest unconfirmed updates, while a negative offset discards older queued updates.
+
+## Fix applied
+
+`save_it` now uses `SaveIt.TelegramPolling` instead of ExGram's default polling worker. The custom worker omits `offset` on the first fetch so Telegram returns the earliest unconfirmed pending updates. After a batch is dispatched, the worker acknowledges processed updates with `max(update_id) + 1`, preserving the existing long-polling flow for future updates.
+
+Regression tests cover both startup behavior without an initial negative offset and the follow-up fetch that acknowledges processed updates.
+
+## What we learned
+
+Pending Telegram update handling depends on the first polling request after startup. A negative offset is a destructive queue operation, so bot startup code should avoid it unless intentionally dropping old updates.

--- a/docs/postmortem/2026-07-06-telegram-rate-limit-notice.md
+++ b/docs/postmortem/2026-07-06-telegram-rate-limit-notice.md
@@ -1,0 +1,21 @@
+# Telegram Rate Limit Notice
+
+## What happened
+
+When Telegram returned a `429 Too Many Requests` response while the bot was sending the initial URL download progress message, the bot process crashed with a `MatchError`. Users did not receive a clear explanation that Telegram was rate limiting the bot, and the URL save was not retried automatically after Telegram's retry window.
+
+## Root cause
+
+The URL save path assumed the first `sendMessage` call always returned `{:ok, progress_message}`. ExGram correctly returned `{:error, %ExGram.Error{code: 429, metadata: %{parameters: %{retry_after: seconds}}}}`, but the bot did not handle that error shape before pattern matching the success tuple.
+
+## Fix applied
+
+Telegram text feedback now detects `429` errors, extracts `retry_after`, and logs the limit. For URL saves, the initial progress-message boundary returns the structured rate-limit result to the URL workflow. The workflow schedules one background retry after the Telegram retry window, sends a user-facing notice with the next automatic retry time, and then re-enters the same URL save flow.
+
+The retry is capped at one automatic attempt. If Telegram still rate limits the retry, the bot sends a final notice after the retry window and does not schedule another retry.
+
+Regression tests cover both the successful one-time retry and the repeated-rate-limit case that must not create an infinite retry loop.
+
+## What we learned
+
+Telegram API calls that exist only to keep the user informed still need explicit error handling. Progress-message failures should stop the visible workflow early, and rate-limit errors should use Telegram's `retry_after` value for user-visible retry scheduling instead of becoming generic runtime exceptions or unbounded retry loops.

--- a/docs/postmortem/2026-07-06-telegram-rate-limit-notice.md
+++ b/docs/postmortem/2026-07-06-telegram-rate-limit-notice.md
@@ -12,6 +12,8 @@ The URL save path assumed the first `sendMessage` call always returned `{:ok, pr
 
 Telegram text feedback now detects `429` errors, extracts `retry_after`, and logs the limit. For URL saves, the initial progress-message boundary returns the structured rate-limit result to the URL workflow. The workflow schedules one background retry after the Telegram retry window, sends a user-facing notice with the next automatic retry time, and then re-enters the same URL save flow.
 
+Telegram feedback and `429` handling now live in `SaveIt.Telegram`, while delayed execution lives in `SaveIt.Job`; `SaveIt.Bot` only calls the Telegram manager from the URL workflow.
+
 The retry is capped at one automatic attempt. If Telegram still rate limits the retry, the bot sends a final notice after the retry window and does not schedule another retry.
 
 Regression tests cover both the successful one-time retry and the repeated-rate-limit case that must not create an infinite retry loop.

--- a/lib/save_it/application.ex
+++ b/lib/save_it/application.ex
@@ -7,26 +7,28 @@ defmodule SaveIt.Application do
 
   @impl true
   def start(_type, _args) do
-    token = Application.fetch_env!(:save_it, :telegram_bot_token) |> require_telegram_bot_token!()
-
     :logger.add_handler(:my_sentry_handler, Sentry.LoggerHandler, %{
       config: %{metadata: [:file, :line]}
     })
 
-    children =
-      if Application.get_env(:save_it, :start_bot?, true) do
-        [
-          ExGram,
-          {SaveIt.Bot, [method: :polling, token: token]}
-        ]
-      else
-        []
-      end
-
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: SaveIt.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link(children(), opts)
+  end
+
+  @doc false
+  def children do
+    token = Application.fetch_env!(:save_it, :telegram_bot_token) |> require_telegram_bot_token!()
+
+    if Application.get_env(:save_it, :start_bot?, true) do
+      [
+        ExGram,
+        {SaveIt.Bot, [method: SaveIt.TelegramPolling, token: token]}
+      ]
+    else
+      []
+    end
   end
 
   defp require_telegram_bot_token!(token) when is_binary(token) do

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -10,6 +10,7 @@ defmodule SaveIt.Bot do
   alias SaveIt.FileHelper
   alias SaveIt.GoogleDrive
   alias SaveIt.GoogleOAuth2DeviceFlow
+  alias SaveIt.Telegram
   alias SaveIt.UrlMetadata
   alias SaveIt.VideoUpload
 
@@ -19,7 +20,7 @@ defmodule SaveIt.Bot do
   alias SmallSdk.Cobalt
   alias SmallSdk.HlsDownloader
   alias SmallSdk.LinkPreview
-  alias SmallSdk.Telegram
+  alias SmallSdk.Telegram, as: TelegramClient
   alias SmallSdk.WebDownloader
 
   @bot :save_it_bot
@@ -33,7 +34,6 @@ defmodule SaveIt.Bot do
 
   @similar_photos_found_message "Similar photos found."
   @telegram_upload_max_file_size 50 * 1024 * 1024
-  @telegram_rate_limit_max_retries 1
   @telegram_file_too_large_message "💔 File is too large for Telegram Bot API upload."
   @telegram_video_too_large_thumbnail_message "Video downloaded; Telegram upload was too large."
 
@@ -63,7 +63,7 @@ defmodule SaveIt.Bot do
   def handle({:command, :about, %{chat: chat}}, _context) do
     bot_info = about_bot_info()
 
-    send_message(chat.id, """
+    Telegram.send_message(chat.id, """
     SaveIt can download images and videos, just give me a link.
 
     Chat: #{about_chat_type(chat)}
@@ -83,10 +83,13 @@ defmodule SaveIt.Bot do
         login_google(chat)
 
       {:error, :not_admin} ->
-        send_message(chat.id, "You are not an administrator, you can't connect Google Drive.")
+        Telegram.send_message(
+          chat.id,
+          "You are not an administrator, you can't connect Google Drive."
+        )
 
       {:error, :unsupported_chat} ->
-        send_message(chat.id, "You can't connect Google Drive in this chat.")
+        Telegram.send_message(chat.id, "You can't connect Google Drive in this chat.")
     end
   end
 
@@ -94,10 +97,10 @@ defmodule SaveIt.Bot do
     folder_id = normalize_command_text(text)
 
     if folder_id == "" do
-      send_message(chat.id, "Please provide a Google Drive folder ID.")
+      Telegram.send_message(chat.id, "Please provide a Google Drive folder ID.")
     else
       FileHelper.set_google_drive_folder_id(chat.id, folder_id)
-      send_message(chat.id, "Google Drive folder ID set successfully.")
+      Telegram.send_message(chat.id, "Google Drive folder ID set successfully.")
     end
   end
 
@@ -106,7 +109,7 @@ defmodule SaveIt.Bot do
   end
 
   def handle({:command, :search, %{chat: chat, text: nil}}, _context) do
-    send_message(
+    Telegram.send_message(
       chat.id,
       "What do you want to search? animal, food, etc. Or upload a photo with /search."
     )
@@ -118,7 +121,7 @@ defmodule SaveIt.Bot do
 
     case q do
       "" ->
-        send_message(chat.id, "What do you want to search? animal, food, etc.")
+        Telegram.send_message(chat.id, "What do you want to search? animal, food, etc.")
 
       _ ->
         photos = safe_typesense_search_photos(q, belongs_to_id: chat.id)
@@ -127,7 +130,7 @@ defmodule SaveIt.Bot do
   end
 
   def handle({:command, :detail, %{chat: chat, reply_to_message: nil}}, _context) do
-    send_message(chat.id, "reply a photo or video with /detail command.")
+    Telegram.send_message(chat.id, "reply a photo or video with /detail command.")
   end
 
   def handle({:command, :detail, %{chat: chat, reply_to_message: reply_to_message}}, _context) do
@@ -136,12 +139,12 @@ defmodule SaveIt.Bot do
         handle_detail_command(chat.id, reply_to_message, file_id)
 
       _ ->
-        send_message(chat.id, "reply a photo or video with /detail command.")
+        Telegram.send_message(chat.id, "reply a photo or video with /detail command.")
     end
   end
 
   def handle({:command, :delete, %{chat: chat, reply_to_message: nil}}, _ctx) do
-    send_message(chat.id, "reply a message with /delete command.")
+    Telegram.send_message(chat.id, "reply a message with /delete command.")
   end
 
   def handle(
@@ -154,7 +157,7 @@ defmodule SaveIt.Bot do
     if Enum.member?([bot_id, from.id], reply_to_message.from.id) do
       handle_delete_command(chat.id, message_id, reply_to_message)
     else
-      send_message(chat.id, "Only delete messages from @#{bot_username} and yourself.")
+      Telegram.send_message(chat.id, "Only delete messages from @#{bot_username} and yourself.")
     end
   end
 
@@ -205,7 +208,7 @@ defmodule SaveIt.Bot do
   end
 
   defp answer_photos(chat_id, []) do
-    send_message(chat_id, "No photos found.")
+    Telegram.send_message(chat_id, "No photos found.")
   end
 
   defp answer_photos(chat_id, [photo]) do
@@ -240,7 +243,7 @@ defmodule SaveIt.Bot do
       |> Enum.any?(&(&1 == :ok))
 
     if has_success? do
-      delete_message(chat.id, message_id)
+      Telegram.delete_message(chat.id, message_id)
     end
   end
 
@@ -264,7 +267,7 @@ defmodule SaveIt.Bot do
   end
 
   defp answer_similar_photos(chat_id, photos) when is_list(photos) do
-    send_message(chat_id, @similar_photos_found_message)
+    Telegram.send_message(chat_id, @similar_photos_found_message)
     answer_photos(chat_id, photos)
   end
 
@@ -276,7 +279,7 @@ defmodule SaveIt.Bot do
   defp handle_uploaded_photo(message, chat, caption, photos) do
     photo = List.last(photos)
     file = ExGram.get_file!(photo.file_id)
-    file_content = Telegram.download_file_content!(file.file_path)
+    file_content = TelegramClient.download_file_content!(file.file_path)
     file_name = telegram_file_name(file, photo.file_id, ".jpg")
 
     FileHelper.write_file(file_name, file_content, telegram_cache_key("photo", file.file_id))
@@ -308,7 +311,7 @@ defmodule SaveIt.Bot do
 
   defp create_video_thumbnail_index(thumbnail, chat, message, caption, file_id) do
     thumbnail_file = ExGram.get_file!(thumbnail.file_id)
-    thumbnail_content = Telegram.download_file_content!(thumbnail_file.file_path)
+    thumbnail_content = TelegramClient.download_file_content!(thumbnail_file.file_path)
 
     %{
       image: Base.encode64(thumbnail_content),
@@ -332,7 +335,7 @@ defmodule SaveIt.Bot do
   end
 
   defp store_uploaded_video_file_content(chat_id, video, file) do
-    case Telegram.download_file_content(file.file_path) do
+    case TelegramClient.download_file_content(file.file_path) do
       {:ok, file_content} ->
         file_name = Map.get(video, :file_name) || telegram_file_name(file, video.file_id, ".mp4")
         FileHelper.write_file(file_name, file_content, telegram_cache_key("video", video.file_id))
@@ -479,7 +482,7 @@ defmodule SaveIt.Bot do
 
     Logger.debug("URL processing started chat_id=#{chat_id} source_url=#{format_log_url(url)}")
 
-    case send_message(chat_id, Enum.at(@progress, 0), on_rate_limit: :return) do
+    case Telegram.send_message(chat_id, Enum.at(@progress, 0), on_rate_limit: :return) do
       {:ok, progress_message} ->
         continue_process_url(chat, url, message, progress_message)
 
@@ -497,17 +500,15 @@ defmodule SaveIt.Bot do
   end
 
   defp handle_rate_limited_url_progress(chat, url, message, retry_after, retry_attempt) do
-    if retry_attempt < @telegram_rate_limit_max_retries do
-      schedule_telegram_rate_limit_retry(chat, url, message, retry_after, retry_attempt + 1)
-    else
-      schedule_telegram_rate_limit_notice(
-        chat.id,
-        retry_after,
-        telegram_rate_limit_final_message()
-      )
-    end
-
-    :error
+    Telegram.handle_progress_rate_limit(
+      chat,
+      message,
+      retry_after,
+      retry_attempt,
+      fn next_attempt ->
+        process_url(chat, url, message, next_attempt)
+      end
+    )
   end
 
   defp continue_process_url(chat, url, message, progress_message) do
@@ -562,7 +563,11 @@ defmodule SaveIt.Bot do
   end
 
   defp handle_hls_download(%DownloadContext{} = context, m3u8_url) do
-    update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..1))
+    Telegram.update_message(
+      context.chat_id,
+      context.progress_message_id,
+      Enum.slice(@progress, 0..1)
+    )
 
     case hls_downloader().download(m3u8_url) do
       {:ok, %DownloadedFile{} = file} ->
@@ -571,7 +576,11 @@ defmodule SaveIt.Bot do
             "download_url=#{format_log_url(context.download_url)}"
         )
 
-        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+        Telegram.update_message(
+          context.chat_id,
+          context.progress_message_id,
+          Enum.slice(@progress, 0..2)
+        )
 
         bot_send_downloaded_file(context.chat_id, file, download_send_opts(context))
 
@@ -592,27 +601,39 @@ defmodule SaveIt.Bot do
         download_and_store_files(context, download_urls)
 
       downloaded_files ->
-        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+        Telegram.update_message(
+          context.chat_id,
+          context.progress_message_id,
+          Enum.slice(@progress, 0..2)
+        )
 
         bot_send_filenames(context.chat_id, downloaded_files, download_send_opts(context))
 
-        delete_message(context.chat_id, context.progress_message_id)
+        Telegram.delete_message(context.chat_id, context.progress_message_id)
         :ok
     end
   end
 
   defp download_and_store_files(%DownloadContext{} = context, download_urls) do
-    update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..1))
+    Telegram.update_message(
+      context.chat_id,
+      context.progress_message_id,
+      Enum.slice(@progress, 0..1)
+    )
 
     case WebDownloader.download_files(download_urls) do
       {:ok, files} ->
         Logger.debug("URL files downloaded file_count=#{length(files)}")
 
-        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+        Telegram.update_message(
+          context.chat_id,
+          context.progress_message_id,
+          Enum.slice(@progress, 0..2)
+        )
 
         bot_send_files(context.chat_id, files, download_send_opts(context))
 
-        delete_message(context.chat_id, context.progress_message_id)
+        Telegram.delete_message(context.chat_id, context.progress_message_id)
         FileHelper.write_folder(context.purge_url, files)
         GoogleDrive.upload_files(context.chat_id, files)
 
@@ -633,7 +654,11 @@ defmodule SaveIt.Bot do
         download_and_store_file(context)
 
       downloaded_file ->
-        update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+        Telegram.update_message(
+          context.chat_id,
+          context.progress_message_id,
+          Enum.slice(@progress, 0..2)
+        )
 
         bot_send_file(
           context.chat_id,
@@ -642,13 +667,17 @@ defmodule SaveIt.Bot do
           download_send_opts(context)
         )
 
-        delete_message(context.chat_id, context.progress_message_id)
+        Telegram.delete_message(context.chat_id, context.progress_message_id)
         :ok
     end
   end
 
   defp download_and_store_file(%DownloadContext{} = context) do
-    update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..1))
+    Telegram.update_message(
+      context.chat_id,
+      context.progress_message_id,
+      Enum.slice(@progress, 0..1)
+    )
 
     case WebDownloader.download_file(context.download_url) do
       {:ok, %DownloadedFile{} = file} ->
@@ -658,7 +687,7 @@ defmodule SaveIt.Bot do
         )
 
         if url_download_media_file?(file.file_name) do
-          update_message(
+          Telegram.update_message(
             context.chat_id,
             context.progress_message_id,
             Enum.slice(@progress, 0..2)
@@ -692,7 +721,12 @@ defmodule SaveIt.Bot do
       {:error, _fallback_reasons} ->
         Logger.warning("No thumbnail fallback available after non-media URL download")
 
-        update_message(context.chat_id, context.progress_message_id, "💔 No image preview found.")
+        Telegram.update_message(
+          context.chat_id,
+          context.progress_message_id,
+          "💔 No image preview found."
+        )
+
         :error
     end
   end
@@ -706,7 +740,7 @@ defmodule SaveIt.Bot do
       {:error, _fallback_reasons} ->
         Logger.warning("No thumbnail fallback available after link download failed")
 
-        update_message(context.chat_id, context.progress_message_id, failure_message)
+        Telegram.update_message(context.chat_id, context.progress_message_id, failure_message)
         :error
     end
   end
@@ -736,7 +770,11 @@ defmodule SaveIt.Bot do
   end
 
   defp save_thumbnail_fallback(%DownloadContext{} = context, %DownloadedFile{} = file, source) do
-    update_message(context.chat_id, context.progress_message_id, Enum.slice(@progress, 0..2))
+    Telegram.update_message(
+      context.chat_id,
+      context.progress_message_id,
+      Enum.slice(@progress, 0..2)
+    )
 
     bot_send_downloaded_file(
       context.chat_id,
@@ -820,7 +858,7 @@ defmodule SaveIt.Bot do
     with thumbnail when not is_nil(thumbnail) <- message_thumbnail(message),
          file_id when is_binary(file_id) <- map_get(thumbnail, :file_id),
          {:ok, file} <- ExGram.get_file(file_id),
-         {:ok, file_content} <- Telegram.download_file_content(file.file_path) do
+         {:ok, file_content} <- TelegramClient.download_file_content(file.file_path) do
       {:ok,
        %DownloadedFile{
          file_name: telegram_file_name(file, file_id, ".jpg"),
@@ -886,7 +924,7 @@ defmodule SaveIt.Bot do
   end
 
   defp finalize_thumbnail_download(%DownloadContext{} = context, %DownloadedFile{} = file) do
-    delete_message(context.chat_id, context.progress_message_id)
+    Telegram.delete_message(context.chat_id, context.progress_message_id)
     FileHelper.write_file(file.file_name, file.file_content, context.original_url)
     GoogleDrive.upload_file_content(context.chat_id, file.file_content, file.file_name)
 
@@ -898,7 +936,7 @@ defmodule SaveIt.Bot do
   end
 
   defp finalize_single_download(%DownloadContext{} = context, %DownloadedFile{} = file) do
-    delete_message(context.chat_id, context.progress_message_id)
+    Telegram.delete_message(context.chat_id, context.progress_message_id)
     FileHelper.write_file(file.file_name, file.file_content, context.cache_url)
     GoogleDrive.upload_file_content(context.chat_id, file.file_content, file.file_name)
 
@@ -924,12 +962,6 @@ defmodule SaveIt.Bot do
   end
 
   defp strip_urls_from_text(_text), do: ""
-
-  defp send_message(chat_id, text, opts \\ []) do
-    chat_id
-    |> ExGram.send_message(text)
-    |> handle_telegram_feedback_result(chat_id, opts)
-  end
 
   defp about_chat_type(%{type: "private"}), do: "dm"
   defp about_chat_type(%{type: "group"}), do: "group"
@@ -976,170 +1008,6 @@ defmodule SaveIt.Bot do
   end
 
   defp about_privacy_mode_status(_bot_info), do: "unknown"
-
-  defp update_message(chat_id, message_id, texts) when is_list(texts) do
-    texts
-    |> Enum.join("\n")
-    |> ExGram.edit_message_text(chat_id: chat_id, message_id: message_id)
-    |> handle_telegram_feedback_result(chat_id, [])
-  end
-
-  defp update_message(chat_id, message_id, text) do
-    text
-    |> ExGram.edit_message_text(chat_id: chat_id, message_id: message_id)
-    |> handle_telegram_feedback_result(chat_id, [])
-  end
-
-  defp handle_telegram_feedback_result({:error, %ExGram.Error{code: 429} = error}, chat_id, opts) do
-    retry_after = telegram_retry_after(error)
-
-    Logger.warning(
-      "Telegram request rate limited chat_id=#{chat_id} " <>
-        "retry_after=#{format_log_value(retry_after)}"
-    )
-
-    case Keyword.get(opts, :on_rate_limit, :notify) do
-      :return ->
-        {:error, {:telegram_rate_limited, retry_after}}
-
-      _other ->
-        schedule_telegram_rate_limit_notice(chat_id, retry_after)
-        {:error, :telegram_rate_limited}
-    end
-  end
-
-  defp handle_telegram_feedback_result(result, _chat_id, _opts), do: result
-
-  defp schedule_telegram_rate_limit_notice(chat_id, retry_after) do
-    schedule_telegram_rate_limit_notice(
-      chat_id,
-      retry_after,
-      telegram_rate_limit_message(retry_after)
-    )
-  end
-
-  defp schedule_telegram_rate_limit_notice(chat_id, retry_after, message) do
-    delay_ms = telegram_rate_limit_delay_ms(retry_after)
-
-    Task.start(fn ->
-      if delay_ms > 0, do: Process.sleep(delay_ms)
-
-      send_telegram_rate_limit_notice(chat_id, message)
-    end)
-
-    :ok
-  end
-
-  defp schedule_telegram_rate_limit_retry(chat, url, message, retry_after, retry_attempt) do
-    delay_ms = telegram_rate_limit_delay_ms(retry_after)
-    retry_at = telegram_retry_at(retry_after)
-    notice = telegram_rate_limit_retry_message(retry_after, retry_at)
-
-    Task.start(fn ->
-      if delay_ms > 0, do: Process.sleep(delay_ms)
-
-      send_telegram_rate_limit_notice(chat.id, notice)
-
-      chat
-      |> process_url(url, message, retry_attempt)
-      |> maybe_delete_source_message_after_retry(chat, message)
-    end)
-
-    :ok
-  end
-
-  defp send_telegram_rate_limit_notice(chat_id, message) do
-    case ExGram.send_message(chat_id, message) do
-      {:ok, _response} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning(
-          "Telegram rate limit notice failed chat_id=#{chat_id} " <>
-            "reason=#{format_log_value(reason)}"
-        )
-    end
-  end
-
-  defp maybe_delete_source_message_after_retry(:ok, chat, message) do
-    case message_id(message) do
-      message_id when is_integer(message_id) -> delete_message(chat.id, message_id)
-      _ -> :ok
-    end
-  end
-
-  defp maybe_delete_source_message_after_retry(_result, _chat, _message), do: :ok
-
-  defp telegram_rate_limit_delay_ms(retry_after) do
-    case Application.fetch_env(:save_it, :telegram_rate_limit_delay_ms) do
-      {:ok, delay_ms} when is_integer(delay_ms) and delay_ms >= 0 -> delay_ms
-      _ -> telegram_retry_after_delay_ms(retry_after)
-    end
-  end
-
-  defp telegram_retry_after_delay_ms(retry_after) do
-    if is_integer(retry_after) and retry_after >= 0, do: retry_after * 1000, else: 0
-  end
-
-  defp telegram_rate_limit_message(nil) do
-    "Telegram is rate limiting me. Please retry later."
-  end
-
-  defp telegram_rate_limit_message(retry_after) do
-    "Telegram is rate limiting me. Please retry after #{retry_after} seconds."
-  end
-
-  defp telegram_rate_limit_retry_message(nil, retry_at) do
-    "Telegram is rate limiting me. Next automatic retry is scheduled for " <>
-      "#{format_telegram_retry_at(retry_at)}. I will only retry automatically once."
-  end
-
-  defp telegram_rate_limit_retry_message(retry_after, retry_at) do
-    "Telegram is rate limiting me. Next automatic retry is scheduled for " <>
-      "#{format_telegram_retry_at(retry_at)} (in #{retry_after} seconds). " <>
-      "I will only retry automatically once."
-  end
-
-  defp telegram_rate_limit_final_message do
-    "Telegram is still rate limiting me. I will not retry automatically again. Please try again later."
-  end
-
-  defp telegram_retry_at(retry_after) when is_integer(retry_after) and retry_after >= 0 do
-    DateTime.utc_now()
-    |> DateTime.add(retry_after, :second)
-  end
-
-  defp telegram_retry_at(_retry_after), do: DateTime.utc_now()
-
-  defp format_telegram_retry_at(%DateTime{} = retry_at) do
-    Calendar.strftime(retry_at, "%Y-%m-%d %H:%M:%S UTC")
-  end
-
-  defp telegram_retry_after(%ExGram.Error{metadata: metadata}) when is_map(metadata) do
-    retry_after =
-      metadata
-      |> map_get(:parameters)
-      |> map_get(:retry_after)
-
-    normalize_retry_after(retry_after)
-  end
-
-  defp telegram_retry_after(_error), do: nil
-
-  defp normalize_retry_after(value) when is_integer(value) and value >= 0, do: value
-
-  defp normalize_retry_after(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {seconds, ""} when seconds >= 0 -> seconds
-      _ -> nil
-    end
-  end
-
-  defp normalize_retry_after(_value), do: nil
-
-  defp delete_message(chat_id, message_id) do
-    ExGram.delete_message(chat_id, message_id)
-  end
 
   defp bot_send_files(chat_id, files, opts) do
     source_url = Keyword.get(opts, :source_url)
@@ -1247,7 +1115,7 @@ defmodule SaveIt.Bot do
     message_thread_id = Keyword.get(opts, :message_thread_id)
     url_metadata_opts = url_metadata_opts(opts)
 
-    case Telegram.send_media_group(chat_id, files,
+    case TelegramClient.send_media_group(chat_id, files,
            caption: caption,
            message_thread_id: message_thread_id
          ) do
@@ -1432,7 +1300,7 @@ defmodule SaveIt.Bot do
         send_oversized_video_preview(chat_id, content, opts)
 
       _extension ->
-        send_message(chat_id, @telegram_file_too_large_message)
+        Telegram.send_message(chat_id, @telegram_file_too_large_message)
         {:error, :telegram_file_too_large}
     end
   end
@@ -1475,7 +1343,7 @@ defmodule SaveIt.Bot do
       :ok
     else
       _reason ->
-        send_message(chat_id, @telegram_file_too_large_message)
+        Telegram.send_message(chat_id, @telegram_file_too_large_message)
         {:error, :telegram_file_too_large}
     end
   end
@@ -1955,31 +1823,31 @@ defmodule SaveIt.Bot do
       {:ok, response} ->
         FileHelper.set_google_device_code(chat.id, response["device_code"])
 
-        send_message(chat.id, """
+        Telegram.send_message(chat.id, """
         Open the following URL in your browser:
         #{response["verification_url"] || response["verification_uri"]}
         Enter code:
         """)
 
-        send_message(chat.id, """
+        Telegram.send_message(chat.id, """
         #{response["user_code"]}
         """)
 
-        send_message(chat.id, """
+        Telegram.send_message(chat.id, """
         After approving access, run `/google_drive_login` again.
         """)
 
       {:error, {:missing_config, key}} ->
         Logger.error("Google Drive login config missing", key: key)
-        send_message(chat.id, missing_google_oauth_config_message(key))
+        Telegram.send_message(chat.id, missing_google_oauth_config_message(key))
 
       {:error, %{body: %{"error" => "invalid_client"}}} ->
         Logger.error("Google Drive login config invalid")
-        send_message(chat.id, invalid_google_oauth_client_message())
+        Telegram.send_message(chat.id, invalid_google_oauth_client_message())
 
       {:error, _error} ->
         Logger.error("Failed to get Google Drive login code")
-        send_message(chat.id, "Failed to get Google Drive login code.")
+        Telegram.send_message(chat.id, "Failed to get Google Drive login code.")
     end
   end
 
@@ -1988,10 +1856,10 @@ defmodule SaveIt.Bot do
       {:ok, %{"access_token" => access_token}} when is_binary(access_token) ->
         FileHelper.set_google_access_token(chat.id, access_token)
         FileHelper.set_google_device_code(chat.id, "")
-        send_message(chat.id, "Google Drive connected.")
+        Telegram.send_message(chat.id, "Google Drive connected.")
 
       {:error, %{body: %{"error" => "authorization_pending"}}} ->
-        send_message(chat.id, """
+        Telegram.send_message(chat.id, """
         Google authorization is not complete yet.
 
         Approve access in your browser, then run `/google_drive_login` again.
@@ -1999,17 +1867,17 @@ defmodule SaveIt.Bot do
 
       {:error, {:missing_config, key}} ->
         Logger.error("Google Drive login config missing", key: key)
-        send_message(chat.id, missing_google_oauth_config_message(key))
+        Telegram.send_message(chat.id, missing_google_oauth_config_message(key))
 
       {:error, %{body: %{"error" => "invalid_client"}}} ->
         FileHelper.set_google_device_code(chat.id, "")
         Logger.error("Google Drive login config invalid")
-        send_message(chat.id, invalid_google_oauth_client_message())
+        Telegram.send_message(chat.id, invalid_google_oauth_client_message())
 
       {:error, %{body: %{"error" => error}}} when error in ["access_denied", "expired_token"] ->
         FileHelper.set_google_device_code(chat.id, "")
 
-        send_message(chat.id, """
+        Telegram.send_message(chat.id, """
         Google Drive login code expired or was denied.
 
         Run `/google_drive_login` to get a new code.
@@ -2018,7 +1886,7 @@ defmodule SaveIt.Bot do
       {:error, _error} ->
         Logger.error("Failed to connect Google Drive")
 
-        send_message(chat.id, """
+        Telegram.send_message(chat.id, """
         Failed to connect Google Drive.
 
         Please run `/google_drive_login` again.
@@ -2081,29 +1949,29 @@ defmodule SaveIt.Bot do
   defp handle_delete_command(chat_id, message_id, reply_to_message) do
     case reply_to_message do
       %{photo: nil} ->
-        delete_message(chat_id, reply_to_message.message_id)
+        Telegram.delete_message(chat_id, reply_to_message.message_id)
 
       %{photo: photo} ->
         photo
         |> Enum.map(& &1.file_id)
         |> PhotoService.delete_photos()
 
-        delete_message(chat_id, reply_to_message.message_id)
+        Telegram.delete_message(chat_id, reply_to_message.message_id)
 
       _ ->
-        send_message(chat_id, "reply a message with /delete command.")
+        Telegram.send_message(chat_id, "reply a message with /delete command.")
     end
 
-    delete_message(chat_id, message_id)
+    Telegram.delete_message(chat_id, message_id)
   end
 
   defp handle_detail_command(chat_id, reply_to_message, file_id) do
     case safe_typesense_get_photo(file_id, chat_id) do
       nil ->
-        send_message(chat_id, "Media details not found.")
+        Telegram.send_message(chat_id, "Media details not found.")
 
       photo ->
-        send_message(chat_id, detail_message(reply_to_message, photo))
+        Telegram.send_message(chat_id, detail_message(reply_to_message, photo))
     end
   end
 

--- a/lib/save_it/bot.ex
+++ b/lib/save_it/bot.ex
@@ -33,6 +33,7 @@ defmodule SaveIt.Bot do
 
   @similar_photos_found_message "Similar photos found."
   @telegram_upload_max_file_size 50 * 1024 * 1024
+  @telegram_rate_limit_max_retries 1
   @telegram_file_too_large_message "💔 File is too large for Telegram Bot API upload."
   @telegram_video_too_large_thumbnail_message "Video downloaded; Telegram upload was too large."
 
@@ -471,15 +472,47 @@ defmodule SaveIt.Bot do
     end
   end
 
-  defp process_url(chat, url, message) do
+  defp process_url(chat, url, message), do: process_url(chat, url, message, 0)
+
+  defp process_url(chat, url, message, retry_attempt) do
     chat_id = chat.id
 
     Logger.debug("URL processing started chat_id=#{chat_id} source_url=#{format_log_url(url)}")
 
-    {:ok, progress_message} = send_message(chat_id, Enum.at(@progress, 0))
+    case send_message(chat_id, Enum.at(@progress, 0), on_rate_limit: :return) do
+      {:ok, progress_message} ->
+        continue_process_url(chat, url, message, progress_message)
 
+      {:error, {:telegram_rate_limited, retry_after}} ->
+        handle_rate_limited_url_progress(chat, url, message, retry_after, retry_attempt)
+
+      {:error, reason} ->
+        Logger.warning(
+          "URL processing stopped before progress message source_url=#{format_log_url(url)} " <>
+            "reason=#{format_log_value(reason)}"
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp handle_rate_limited_url_progress(chat, url, message, retry_after, retry_attempt) do
+    if retry_attempt < @telegram_rate_limit_max_retries do
+      schedule_telegram_rate_limit_retry(chat, url, message, retry_after, retry_attempt + 1)
+    else
+      schedule_telegram_rate_limit_notice(
+        chat.id,
+        retry_after,
+        telegram_rate_limit_final_message()
+      )
+    end
+
+    :error
+  end
+
+  defp continue_process_url(chat, url, message, progress_message) do
     context = %DownloadContext{
-      chat_id: chat_id,
+      chat_id: chat.id,
       chat: chat,
       progress_message_id: progress_message.message_id,
       original_url: url,
@@ -892,8 +925,10 @@ defmodule SaveIt.Bot do
 
   defp strip_urls_from_text(_text), do: ""
 
-  defp send_message(chat_id, text) do
-    ExGram.send_message(chat_id, text)
+  defp send_message(chat_id, text, opts \\ []) do
+    chat_id
+    |> ExGram.send_message(text)
+    |> handle_telegram_feedback_result(chat_id, opts)
   end
 
   defp about_chat_type(%{type: "private"}), do: "dm"
@@ -943,12 +978,164 @@ defmodule SaveIt.Bot do
   defp about_privacy_mode_status(_bot_info), do: "unknown"
 
   defp update_message(chat_id, message_id, texts) when is_list(texts) do
-    ExGram.edit_message_text(Enum.join(texts, "\n"), chat_id: chat_id, message_id: message_id)
+    texts
+    |> Enum.join("\n")
+    |> ExGram.edit_message_text(chat_id: chat_id, message_id: message_id)
+    |> handle_telegram_feedback_result(chat_id, [])
   end
 
   defp update_message(chat_id, message_id, text) do
-    ExGram.edit_message_text(text, chat_id: chat_id, message_id: message_id)
+    text
+    |> ExGram.edit_message_text(chat_id: chat_id, message_id: message_id)
+    |> handle_telegram_feedback_result(chat_id, [])
   end
+
+  defp handle_telegram_feedback_result({:error, %ExGram.Error{code: 429} = error}, chat_id, opts) do
+    retry_after = telegram_retry_after(error)
+
+    Logger.warning(
+      "Telegram request rate limited chat_id=#{chat_id} " <>
+        "retry_after=#{format_log_value(retry_after)}"
+    )
+
+    case Keyword.get(opts, :on_rate_limit, :notify) do
+      :return ->
+        {:error, {:telegram_rate_limited, retry_after}}
+
+      _other ->
+        schedule_telegram_rate_limit_notice(chat_id, retry_after)
+        {:error, :telegram_rate_limited}
+    end
+  end
+
+  defp handle_telegram_feedback_result(result, _chat_id, _opts), do: result
+
+  defp schedule_telegram_rate_limit_notice(chat_id, retry_after) do
+    schedule_telegram_rate_limit_notice(
+      chat_id,
+      retry_after,
+      telegram_rate_limit_message(retry_after)
+    )
+  end
+
+  defp schedule_telegram_rate_limit_notice(chat_id, retry_after, message) do
+    delay_ms = telegram_rate_limit_delay_ms(retry_after)
+
+    Task.start(fn ->
+      if delay_ms > 0, do: Process.sleep(delay_ms)
+
+      send_telegram_rate_limit_notice(chat_id, message)
+    end)
+
+    :ok
+  end
+
+  defp schedule_telegram_rate_limit_retry(chat, url, message, retry_after, retry_attempt) do
+    delay_ms = telegram_rate_limit_delay_ms(retry_after)
+    retry_at = telegram_retry_at(retry_after)
+    notice = telegram_rate_limit_retry_message(retry_after, retry_at)
+
+    Task.start(fn ->
+      if delay_ms > 0, do: Process.sleep(delay_ms)
+
+      send_telegram_rate_limit_notice(chat.id, notice)
+
+      chat
+      |> process_url(url, message, retry_attempt)
+      |> maybe_delete_source_message_after_retry(chat, message)
+    end)
+
+    :ok
+  end
+
+  defp send_telegram_rate_limit_notice(chat_id, message) do
+    case ExGram.send_message(chat_id, message) do
+      {:ok, _response} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "Telegram rate limit notice failed chat_id=#{chat_id} " <>
+            "reason=#{format_log_value(reason)}"
+        )
+    end
+  end
+
+  defp maybe_delete_source_message_after_retry(:ok, chat, message) do
+    case message_id(message) do
+      message_id when is_integer(message_id) -> delete_message(chat.id, message_id)
+      _ -> :ok
+    end
+  end
+
+  defp maybe_delete_source_message_after_retry(_result, _chat, _message), do: :ok
+
+  defp telegram_rate_limit_delay_ms(retry_after) do
+    case Application.fetch_env(:save_it, :telegram_rate_limit_delay_ms) do
+      {:ok, delay_ms} when is_integer(delay_ms) and delay_ms >= 0 -> delay_ms
+      _ -> telegram_retry_after_delay_ms(retry_after)
+    end
+  end
+
+  defp telegram_retry_after_delay_ms(retry_after) do
+    if is_integer(retry_after) and retry_after >= 0, do: retry_after * 1000, else: 0
+  end
+
+  defp telegram_rate_limit_message(nil) do
+    "Telegram is rate limiting me. Please retry later."
+  end
+
+  defp telegram_rate_limit_message(retry_after) do
+    "Telegram is rate limiting me. Please retry after #{retry_after} seconds."
+  end
+
+  defp telegram_rate_limit_retry_message(nil, retry_at) do
+    "Telegram is rate limiting me. Next automatic retry is scheduled for " <>
+      "#{format_telegram_retry_at(retry_at)}. I will only retry automatically once."
+  end
+
+  defp telegram_rate_limit_retry_message(retry_after, retry_at) do
+    "Telegram is rate limiting me. Next automatic retry is scheduled for " <>
+      "#{format_telegram_retry_at(retry_at)} (in #{retry_after} seconds). " <>
+      "I will only retry automatically once."
+  end
+
+  defp telegram_rate_limit_final_message do
+    "Telegram is still rate limiting me. I will not retry automatically again. Please try again later."
+  end
+
+  defp telegram_retry_at(retry_after) when is_integer(retry_after) and retry_after >= 0 do
+    DateTime.utc_now()
+    |> DateTime.add(retry_after, :second)
+  end
+
+  defp telegram_retry_at(_retry_after), do: DateTime.utc_now()
+
+  defp format_telegram_retry_at(%DateTime{} = retry_at) do
+    Calendar.strftime(retry_at, "%Y-%m-%d %H:%M:%S UTC")
+  end
+
+  defp telegram_retry_after(%ExGram.Error{metadata: metadata}) when is_map(metadata) do
+    retry_after =
+      metadata
+      |> map_get(:parameters)
+      |> map_get(:retry_after)
+
+    normalize_retry_after(retry_after)
+  end
+
+  defp telegram_retry_after(_error), do: nil
+
+  defp normalize_retry_after(value) when is_integer(value) and value >= 0, do: value
+
+  defp normalize_retry_after(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {seconds, ""} when seconds >= 0 -> seconds
+      _ -> nil
+    end
+  end
+
+  defp normalize_retry_after(_value), do: nil
 
   defp delete_message(chat_id, message_id) do
     ExGram.delete_message(chat_id, message_id)

--- a/lib/save_it/job.ex
+++ b/lib/save_it/job.ex
@@ -1,0 +1,14 @@
+defmodule SaveIt.Job do
+  @moduledoc false
+
+  def run_after(delay_ms, fun)
+      when is_integer(delay_ms) and delay_ms >= 0 and is_function(fun, 0) do
+    Task.start(fn ->
+      if delay_ms > 0, do: Process.sleep(delay_ms)
+
+      fun.()
+    end)
+
+    :ok
+  end
+end

--- a/lib/save_it/telegram.ex
+++ b/lib/save_it/telegram.ex
@@ -182,6 +182,5 @@ defmodule SaveIt.Telegram do
   end
 
   defp format_log_value(nil), do: "nil"
-  defp format_log_value(value) when is_binary(value), do: inspect(value)
   defp format_log_value(value), do: inspect(value)
 end

--- a/lib/save_it/telegram.ex
+++ b/lib/save_it/telegram.ex
@@ -1,0 +1,187 @@
+defmodule SaveIt.Telegram do
+  @moduledoc false
+
+  require Logger
+
+  alias SaveIt.Job
+
+  @rate_limit_max_retries 1
+
+  def send_message(chat_id, text, opts \\ []) do
+    chat_id
+    |> ExGram.send_message(text)
+    |> handle_feedback_result(chat_id, opts)
+  end
+
+  def update_message(chat_id, message_id, texts) when is_list(texts) do
+    update_message(chat_id, message_id, Enum.join(texts, "\n"))
+  end
+
+  def update_message(chat_id, message_id, text) do
+    text
+    |> ExGram.edit_message_text(chat_id: chat_id, message_id: message_id)
+    |> handle_feedback_result(chat_id, [])
+  end
+
+  def delete_message(chat_id, message_id) do
+    ExGram.delete_message(chat_id, message_id)
+  end
+
+  def handle_progress_rate_limit(chat, source_message, retry_after, retry_attempt, retry_fun)
+      when is_function(retry_fun, 1) do
+    if retry_attempt < @rate_limit_max_retries do
+      schedule_progress_retry(chat, source_message, retry_after, retry_attempt + 1, retry_fun)
+    else
+      schedule_notice(chat.id, retry_after, rate_limit_final_message())
+    end
+
+    :error
+  end
+
+  defp handle_feedback_result({:error, %ExGram.Error{code: 429} = error}, chat_id, opts) do
+    retry_after = retry_after(error)
+
+    Logger.warning(
+      "Telegram request rate limited chat_id=#{chat_id} " <>
+        "retry_after=#{format_log_value(retry_after)}"
+    )
+
+    case Keyword.get(opts, :on_rate_limit, :notify) do
+      :return ->
+        {:error, {:telegram_rate_limited, retry_after}}
+
+      _other ->
+        schedule_notice(chat_id, retry_after)
+        {:error, :telegram_rate_limited}
+    end
+  end
+
+  defp handle_feedback_result(result, _chat_id, _opts), do: result
+
+  defp schedule_notice(chat_id, retry_after) do
+    schedule_notice(chat_id, retry_after, rate_limit_message(retry_after))
+  end
+
+  defp schedule_notice(chat_id, retry_after, message) do
+    Job.run_after(rate_limit_delay_ms(retry_after), fn ->
+      send_rate_limit_notice(chat_id, message)
+    end)
+  end
+
+  defp schedule_progress_retry(chat, source_message, retry_after, retry_attempt, retry_fun) do
+    delay_ms = rate_limit_delay_ms(retry_after)
+    retry_at = retry_at(retry_after)
+    notice = rate_limit_retry_message(retry_after, retry_at)
+
+    Job.run_after(delay_ms, fn ->
+      send_rate_limit_notice(chat.id, notice)
+
+      retry_attempt
+      |> retry_fun.()
+      |> maybe_delete_source_message_after_retry(chat, source_message)
+    end)
+  end
+
+  defp send_rate_limit_notice(chat_id, message) do
+    case ExGram.send_message(chat_id, message) do
+      {:ok, _response} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "Telegram rate limit notice failed chat_id=#{chat_id} " <>
+            "reason=#{format_log_value(reason)}"
+        )
+    end
+  end
+
+  defp maybe_delete_source_message_after_retry(:ok, chat, source_message) do
+    case message_id(source_message) do
+      message_id when is_integer(message_id) -> delete_message(chat.id, message_id)
+      _ -> :ok
+    end
+  end
+
+  defp maybe_delete_source_message_after_retry(_result, _chat, _source_message), do: :ok
+
+  defp rate_limit_delay_ms(retry_after) do
+    case Application.fetch_env(:save_it, :telegram_rate_limit_delay_ms) do
+      {:ok, delay_ms} when is_integer(delay_ms) and delay_ms >= 0 -> delay_ms
+      _ -> retry_after_delay_ms(retry_after)
+    end
+  end
+
+  defp retry_after_delay_ms(retry_after) do
+    if is_integer(retry_after) and retry_after >= 0, do: retry_after * 1000, else: 0
+  end
+
+  defp rate_limit_message(nil) do
+    "Telegram is rate limiting me. Please retry later."
+  end
+
+  defp rate_limit_message(retry_after) do
+    "Telegram is rate limiting me. Please retry after #{retry_after} seconds."
+  end
+
+  defp rate_limit_retry_message(nil, retry_at) do
+    "Telegram is rate limiting me. Next automatic retry is scheduled for " <>
+      "#{format_retry_at(retry_at)}. I will only retry automatically once."
+  end
+
+  defp rate_limit_retry_message(retry_after, retry_at) do
+    "Telegram is rate limiting me. Next automatic retry is scheduled for " <>
+      "#{format_retry_at(retry_at)} (in #{retry_after} seconds). " <>
+      "I will only retry automatically once."
+  end
+
+  defp rate_limit_final_message do
+    "Telegram is still rate limiting me. I will not retry automatically again. Please try again later."
+  end
+
+  defp retry_at(retry_after) when is_integer(retry_after) and retry_after >= 0 do
+    DateTime.utc_now()
+    |> DateTime.add(retry_after, :second)
+  end
+
+  defp retry_at(_retry_after), do: DateTime.utc_now()
+
+  defp format_retry_at(%DateTime{} = retry_at) do
+    Calendar.strftime(retry_at, "%Y-%m-%d %H:%M:%S UTC")
+  end
+
+  defp retry_after(%ExGram.Error{metadata: metadata}) when is_map(metadata) do
+    metadata
+    |> map_get(:parameters)
+    |> map_get(:retry_after)
+    |> normalize_retry_after()
+  end
+
+  defp retry_after(_error), do: nil
+
+  defp normalize_retry_after(value) when is_integer(value) and value >= 0, do: value
+
+  defp normalize_retry_after(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {seconds, ""} when seconds >= 0 -> seconds
+      _ -> nil
+    end
+  end
+
+  defp normalize_retry_after(_value), do: nil
+
+  defp message_id(message) when is_map(message) do
+    map_get(message, :message_id)
+  end
+
+  defp message_id(_message), do: nil
+
+  defp map_get(nil, _key), do: nil
+
+  defp map_get(map, key) when is_map(map) do
+    Map.get(map, key) || Map.get(map, to_string(key))
+  end
+
+  defp format_log_value(nil), do: "nil"
+  defp format_log_value(value) when is_binary(value), do: inspect(value)
+  defp format_log_value(value), do: inspect(value)
+end

--- a/lib/save_it/telegram_polling.ex
+++ b/lib/save_it/telegram_polling.ex
@@ -1,0 +1,118 @@
+defmodule SaveIt.TelegramPolling do
+  @moduledoc """
+  ExGram polling worker that keeps Telegram's pending update queue intact on startup.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @polling_timeout 100
+  @default_opts [limit: 100, timeout: 50]
+
+  def start_link(%{bot: bot, token: token} = opts) do
+    opts = Map.drop(opts, [:bot, :token])
+    GenServer.start_link(__MODULE__, {:ok, bot, token, opts})
+  end
+
+  @impl GenServer
+  def init({:ok, bot, token, opts}) do
+    Process.flag(:trap_exit, true)
+    start_time = ExGram.Telemetry.start([:updates, :init], %{bot: bot, method: :polling})
+    opts = :ex_gram |> ExGram.Config.get(:polling, []) |> Keyword.merge(Keyword.new(opts))
+
+    if Keyword.get(opts, :delete_webhook, true) do
+      ExGram.delete_webhook(token: token)
+    end
+
+    Process.send_after(self(), {:fetch, :update_id}, @polling_timeout)
+    ExGram.Telemetry.stop([:updates, :init], start_time, %{bot: bot, method: :polling})
+    {:ok, {bot, token, nil, opts}}
+  end
+
+  @impl GenServer
+  def terminate(_reason, {bot, _token, _uid, _opts}) do
+    ExGram.Telemetry.emit([:updates, :shutdown], %{bot: bot, method: :polling})
+  end
+
+  @impl GenServer
+  def handle_cast({:fetch, :update_id} = message, state), do: handle_info(message, state)
+
+  @impl GenServer
+  def handle_info(:timeout, state), do: handle_info({:fetch, :update_id}, state)
+
+  @impl GenServer
+  def handle_info({:fetch, :update_id}, {bot, token, uid, opts}) do
+    start_meta = %{bot: bot}
+    start_time = ExGram.Telemetry.start(:polling, start_meta)
+
+    try do
+      updates = get_updates(token, uid, opts)
+      send_updates(updates, bot)
+
+      next_uid = next_update_id(uid, updates)
+
+      ExGram.Telemetry.stop(:polling, start_time, %{bot: bot, updates_count: length(updates)})
+
+      {:noreply, {bot, token, next_uid, opts}, @polling_timeout}
+    rescue
+      error ->
+        ExGram.Telemetry.exception(
+          :polling,
+          start_time,
+          :error,
+          error,
+          __STACKTRACE__,
+          start_meta
+        )
+
+        reraise error, __STACKTRACE__
+    catch
+      kind, reason ->
+        ExGram.Telemetry.exception(:polling, start_time, kind, reason, __STACKTRACE__, start_meta)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    end
+  end
+
+  def handle_info(unknown_message, state) do
+    Logger.debug("Polling updates received an unknown message #{inspect(unknown_message)}")
+
+    {:noreply, state, @polling_timeout}
+  end
+
+  defp get_updates(token, uid, opts) do
+    opts = Keyword.take(opts, [:allowed_updates])
+
+    opts =
+      @default_opts
+      |> Keyword.merge(opts)
+      |> maybe_put_offset(uid)
+      |> Keyword.put(:token, token)
+
+    try do
+      ExGram.get_updates!(opts)
+    rescue
+      error in ExGram.Error ->
+        formatted_error = Exception.format(:error, error, __STACKTRACE__)
+        Logger.error("[ExGram] Error fetching updates: #{formatted_error}")
+        []
+    end
+  end
+
+  defp maybe_put_offset(opts, nil), do: opts
+  defp maybe_put_offset(opts, uid), do: Keyword.put(opts, :offset, uid)
+
+  defp send_updates(updates, bot) do
+    Enum.map(updates, &GenServer.call(bot, {:update, &1}))
+  end
+
+  defp next_update_id(actual, []), do: actual
+
+  defp next_update_id(actual, updates) do
+    updates
+    |> Stream.map(&(&1.update_id + 1))
+    |> Enum.reduce(actual, fn update_id, acc ->
+      if is_nil(acc), do: update_id, else: max(update_id, acc)
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule SaveIt.MixProject do
   def project do
     [
       app: :save_it,
-      version: "2026.7.2",
+      version: "2026.7.6-rc.1",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/others/postmortem/2026-07-06-telegram-pending-updates.md
+++ b/others/postmortem/2026-07-06-telegram-pending-updates.md
@@ -1,0 +1,21 @@
+# Telegram Pending Updates Dropped on Startup
+
+## What happened
+
+When the bot was offline and a user sent multiple URL messages, restarting the bot processed only the newest pending message. Older pending URL messages disappeared from the Telegram update queue and were never saved.
+
+## Root cause
+
+`save_it` used ExGram's default polling worker. On startup that worker initialized its first `getUpdates` request with `offset: -1`. Telegram Bot API treats a negative offset as a request for updates from the end of the queue; `-1` returns only the latest pending update and forgets all previous updates.
+
+This was not caused by a recent Telegram Bot API behavior change. The current Bot API still documents that omitting `offset` returns the earliest unconfirmed updates, while a negative offset discards older queued updates.
+
+## Fix applied
+
+`save_it` now uses `SaveIt.TelegramPolling` instead of ExGram's default polling worker. The custom worker omits `offset` on the first fetch so Telegram returns the earliest unconfirmed pending updates. After a batch is dispatched, the worker acknowledges processed updates with `max(update_id) + 1`, preserving the existing long-polling flow for future updates.
+
+Regression tests cover both startup behavior without an initial negative offset and the follow-up fetch that acknowledges processed updates.
+
+## What we learned
+
+Pending Telegram update handling depends on the first polling request after startup. A negative offset is a destructive queue operation, so bot startup code should avoid it unless intentionally dropping old updates.

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -711,6 +711,92 @@ defmodule SaveIt.BotTest do
            end)
   end
 
+  test "automatically retries once when Telegram rate limits the initial URL progress message", %{
+    base_url: base_url
+  } do
+    Application.put_env(:ex_gram, :adapter, __MODULE__.RateLimitedProgressMessageAdapter)
+    Application.put_env(:save_it, :telegram_rate_limit_delay_ms, 0)
+    Application.put_env(:save_it, :rate_limited_progress_failures, 1)
+    Application.put_env(:save_it, :test_pid, self())
+
+    original_url = base_url <> "/photo-page"
+
+    message = %{
+      chat: %{id: 12_345},
+      message_id: 109,
+      text: original_url
+    }
+
+    assert is_nil(Bot.handle({:text, original_url, message}, nil))
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: "Searching 🔎"}}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: retry_notice}}
+
+    assert retry_notice =~ "Telegram is rate limiting me."
+    assert retry_notice =~ "Next automatic retry"
+    assert retry_notice =~ "in 37 seconds"
+    assert retry_notice =~ "only retry automatically once"
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: "Searching 🔎"}}
+
+    assert_receive {:test_http_request, :post, "/", cobalt_body}
+    assert Jason.decode!(cobalt_body) == %{"url" => original_url}
+    assert_receive {:test_http_request, :get, "/photo-page", ""}
+    assert_receive {:test_http_request, :post, "/collections/photos/documents", typesense_body}
+
+    document = Jason.decode!(typesense_body)
+
+    assert document["url"] == original_url
+    assert document["file_id"] == "telegram-photo-file-id"
+    assert_receive {:exgram_request, :post, "/bottest-token/deleteMessage", %{message_id: 109}}
+  end
+
+  test "does not retry more than once when Telegram keeps rate limiting progress messages", %{
+    base_url: base_url
+  } do
+    Application.put_env(:ex_gram, :adapter, __MODULE__.RateLimitedProgressMessageAdapter)
+    Application.put_env(:save_it, :telegram_rate_limit_delay_ms, 0)
+    Application.put_env(:save_it, :rate_limited_progress_failures, 2)
+    Application.put_env(:save_it, :test_pid, self())
+
+    original_url = base_url <> "/photo-page"
+
+    message = %{
+      chat: %{id: 12_345},
+      message_id: 110,
+      text: original_url
+    }
+
+    assert is_nil(Bot.handle({:text, original_url, message}, nil))
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: "Searching 🔎"}}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: retry_notice}}
+
+    assert retry_notice =~ "Next automatic retry"
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: "Searching 🔎"}}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: final_notice}}
+
+    assert final_notice =~ "Telegram is still rate limiting me."
+    assert final_notice =~ "I will not retry automatically again."
+
+    refute_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: "Searching 🔎"}},
+                   50
+
+    refute_receive {:test_http_request, :post, "/", _body}, 50
+  end
+
   test "stores the webpage preview image when Telegram does not include thumbnail media", %{
     base_url: base_url
   } do
@@ -2280,6 +2366,60 @@ defmodule SaveIt.BotTest do
              message_id: 71,
              chat: %{id: chat_id},
              video: %{file_id: "sent-video-file-id"}
+           }}
+
+        _ ->
+          {:error, %ExGram.Error{code: 404}}
+      end
+    end
+
+    defp multipart_value(parts, name) do
+      Enum.find_value(parts, fn
+        {^name, value} -> value
+        _part -> nil
+      end)
+    end
+  end
+
+  defmodule RateLimitedProgressMessageAdapter do
+    @behaviour ExGram.Adapter
+
+    @impl ExGram.Adapter
+    def request(verb, path, body, _opts) do
+      send(Application.fetch_env!(:save_it, :test_pid), {:exgram_request, verb, path, body})
+
+      case {verb, path, body} do
+        {:post, "/bottest-token/sendMessage", %{text: "Searching 🔎"}} ->
+          progress_attempts = Application.get_env(:save_it, :rate_limited_progress_attempts, 0)
+          max_failures = Application.get_env(:save_it, :rate_limited_progress_failures, 1)
+          Application.put_env(:save_it, :rate_limited_progress_attempts, progress_attempts + 1)
+
+          if progress_attempts < max_failures do
+            {:error,
+             %ExGram.Error{
+               code: 429,
+               message: "Too Many Requests: retry after 37",
+               metadata: %{parameters: %{retry_after: 37}}
+             }}
+          else
+            {:ok, %{message_id: 73, chat: %{id: body.chat_id}}}
+          end
+
+        {:post, "/bottest-token/sendMessage", %{chat_id: chat_id}} ->
+          {:ok, %{message_id: 73, chat: %{id: chat_id}}}
+
+        {:post, "/bottest-token/editMessageText", _body} ->
+          {:ok, %{message_id: 73}}
+
+        {:post, "/bottest-token/deleteMessage", _body} ->
+          {:ok, true}
+
+        {:post, "/bottest-token/sendPhoto", {:multipart, parts}} ->
+          {:ok,
+           %{
+             message_id: 74,
+             chat: %{id: multipart_value(parts, "chat_id") |> String.to_integer()},
+             photo: [%{file_id: "telegram-photo-file-id"}]
            }}
 
         _ ->

--- a/test/save_it/application_test.exs
+++ b/test/save_it/application_test.exs
@@ -3,9 +3,11 @@ defmodule SaveIt.ApplicationTest do
 
   setup do
     previous_token = Application.get_env(:save_it, :telegram_bot_token)
+    previous_start_bot = Application.get_env(:save_it, :start_bot?)
 
     on_exit(fn ->
       restore_env(:save_it, :telegram_bot_token, previous_token)
+      restore_env(:save_it, :start_bot?, previous_start_bot)
     end)
   end
 
@@ -23,6 +25,13 @@ defmodule SaveIt.ApplicationTest do
     assert_raise RuntimeError, ~r/TELEGRAM_BOT_TOKEN must be set/, fn ->
       SaveIt.Application.start(:normal, [])
     end
+  end
+
+  test "uses polling that keeps pending Telegram updates on startup" do
+    Application.put_env(:save_it, :telegram_bot_token, "test-token")
+    Application.put_env(:save_it, :start_bot?, true)
+
+    assert {SaveIt.Bot, [method: SaveIt.TelegramPolling, token: "test-token"]} in SaveIt.Application.children()
   end
 
   defp restore_env(app, key, nil), do: Application.delete_env(app, key)

--- a/test/save_it/job_test.exs
+++ b/test/save_it/job_test.exs
@@ -1,0 +1,13 @@
+defmodule SaveIt.JobTest do
+  use ExUnit.Case, async: true
+
+  alias SaveIt.Job
+
+  test "runs a callback after the configured delay" do
+    parent = self()
+
+    assert :ok = Job.run_after(0, fn -> send(parent, :job_ran) end)
+
+    assert_receive :job_ran
+  end
+end

--- a/test/save_it/telegram_polling_test.exs
+++ b/test/save_it/telegram_polling_test.exs
@@ -1,0 +1,98 @@
+defmodule SaveIt.TelegramPollingTest do
+  use ExUnit.Case, async: false
+
+  alias SaveIt.TelegramPolling
+
+  setup do
+    previous_ex_gram = Application.get_all_env(:ex_gram)
+    previous_save_it = Application.get_all_env(:save_it)
+
+    Application.put_env(:ex_gram, :adapter, __MODULE__.Adapter)
+    Application.put_env(:save_it, :test_pid, self())
+
+    on_exit(fn ->
+      restore_env(:ex_gram, previous_ex_gram)
+      restore_env(:save_it, previous_save_it)
+    end)
+
+    :ok
+  end
+
+  test "initial fetch starts from the earliest unconfirmed update" do
+    Application.put_env(:save_it, :polling_test_updates, [])
+
+    {:ok, dispatcher} = GenServer.start_link(__MODULE__.Dispatcher, self())
+    {:ok, polling} = TelegramPolling.start_link(%{bot: dispatcher, token: "test-token"})
+
+    assert_receive {:telegram_request, :get, "/bottest-token/getUpdates", body}, 500
+    refute Map.has_key?(body, :offset)
+    assert body.limit == 100
+    assert body.timeout == 50
+
+    GenServer.stop(polling)
+    GenServer.stop(dispatcher)
+  end
+
+  test "next fetch acknowledges processed updates" do
+    Application.put_env(:save_it, :polling_test_updates, [
+      %{update_id: 41, message: %{message_id: 1, chat: %{id: 123}}}
+    ])
+
+    {:ok, dispatcher} = GenServer.start_link(__MODULE__.Dispatcher, self())
+    {:ok, polling} = TelegramPolling.start_link(%{bot: dispatcher, token: "test-token"})
+
+    assert_receive {:telegram_request, :get, "/bottest-token/getUpdates", first_body}, 500
+    refute Map.has_key?(first_body, :offset)
+    assert_receive {:dispatched_update, 41}
+
+    send(polling, {:fetch, :update_id})
+
+    assert_receive {:telegram_request, :get, "/bottest-token/getUpdates", second_body}, 500
+    assert second_body.offset == 42
+
+    GenServer.stop(polling)
+    GenServer.stop(dispatcher)
+  end
+
+  defmodule Dispatcher do
+    use GenServer
+
+    @impl GenServer
+    def init(parent), do: {:ok, parent}
+
+    @impl GenServer
+    def handle_call({:update, update}, _from, parent) do
+      send(parent, {:dispatched_update, update.update_id})
+      {:reply, :ok, parent}
+    end
+  end
+
+  defmodule Adapter do
+    @behaviour ExGram.Adapter
+
+    @impl ExGram.Adapter
+    def request(verb, path, body, _opts) do
+      send(Application.fetch_env!(:save_it, :test_pid), {:telegram_request, verb, path, body})
+
+      case {verb, path, body} do
+        {:post, "/bottest-token/deleteWebhook", _body} ->
+          {:ok, true}
+
+        {:get, "/bottest-token/getUpdates", %{offset: 42}} ->
+          {:ok, []}
+
+        {:get, "/bottest-token/getUpdates", body} when not is_map_key(body, :offset) ->
+          {:ok, Application.fetch_env!(:save_it, :polling_test_updates)}
+      end
+    end
+  end
+
+  defp restore_env(app, env) do
+    app
+    |> Application.get_all_env()
+    |> Keyword.keys()
+    |> Enum.each(&Application.delete_env(app, &1))
+
+    Enum.each(env, fn {key, value} -> Application.put_env(app, key, value) end)
+  end
+end

--- a/test/save_it/telegram_test.exs
+++ b/test/save_it/telegram_test.exs
@@ -1,0 +1,92 @@
+defmodule SaveIt.TelegramTest do
+  use ExUnit.Case, async: false
+
+  alias SaveIt.Telegram
+
+  setup do
+    previous_ex_gram = Application.get_all_env(:ex_gram)
+    previous_save_it = Application.get_all_env(:save_it)
+
+    Application.put_env(:ex_gram, :adapter, __MODULE__.Adapter)
+    Application.put_env(:ex_gram, :token, "test-token")
+    Application.put_env(:save_it, :telegram_rate_limit_delay_ms, 0)
+    Application.put_env(:save_it, :test_pid, self())
+
+    on_exit(fn ->
+      restore_env(:ex_gram, previous_ex_gram)
+      restore_env(:save_it, previous_save_it)
+    end)
+
+    :ok
+  end
+
+  test "returns structured rate limit errors when requested" do
+    assert {:error, {:telegram_rate_limited, 37}} =
+             Telegram.send_message(12_345, "rate-limited", on_rate_limit: :return)
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: "rate-limited"}}
+  end
+
+  test "schedules one progress retry and deletes the source message after success" do
+    parent = self()
+    chat = %{id: 12_345}
+    source_message = %{message_id: 109}
+
+    assert :error =
+             Telegram.handle_progress_rate_limit(chat, source_message, 37, 0, fn retry_attempt ->
+               send(parent, {:retry, retry_attempt})
+               :ok
+             end)
+
+    assert_receive {:exgram_request, :post, "/bottest-token/sendMessage",
+                    %{chat_id: 12_345, text: retry_notice}}
+
+    assert retry_notice =~ "Telegram is rate limiting me."
+    assert retry_notice =~ "Next automatic retry"
+    assert retry_notice =~ "in 37 seconds"
+    assert retry_notice =~ "only retry automatically once"
+
+    assert_receive {:retry, 1}
+
+    assert_receive {:exgram_request, :post, "/bottest-token/deleteMessage",
+                    %{chat_id: 12_345, message_id: 109}}
+  end
+
+  defmodule Adapter do
+    @behaviour ExGram.Adapter
+
+    @impl ExGram.Adapter
+    def request(verb, path, body, _opts) do
+      send(Application.fetch_env!(:save_it, :test_pid), {:exgram_request, verb, path, body})
+
+      case {verb, path, body} do
+        {:post, "/bottest-token/sendMessage", %{text: "rate-limited"}} ->
+          {:error,
+           %ExGram.Error{
+             code: 429,
+             message: "Too Many Requests: retry after 37",
+             metadata: %{parameters: %{retry_after: 37}}
+           }}
+
+        {:post, "/bottest-token/sendMessage", %{chat_id: chat_id}} ->
+          {:ok, %{message_id: 73, chat: %{id: chat_id}}}
+
+        {:post, "/bottest-token/deleteMessage", _body} ->
+          {:ok, true}
+
+        _ ->
+          {:error, %ExGram.Error{code: 404}}
+      end
+    end
+  end
+
+  defp restore_env(app, env) do
+    app
+    |> Application.get_all_env()
+    |> Keyword.keys()
+    |> Enum.each(&Application.delete_env(app, &1))
+
+    Enum.each(env, fn {key, value} -> Application.put_env(app, key, value) end)
+  end
+end


### PR DESCRIPTION
## Summary

<img width="1684" height="141" alt="image" src="https://github.com/user-attachments/assets/8731ad69-cfdd-46d8-8e32-71ccf4cd78f8" />


- Handle Telegram `429 Too Many Requests` responses when the initial URL progress message is rate limited.
- Tell users when the automatic retry is scheduled and retry the URL save once after Telegram's retry window.
- Preserve Telegram pending updates on bot startup by omitting the destructive initial negative `getUpdates` offset.
- Extract Telegram feedback/rate-limit handling into `SaveIt.Telegram` and keep delayed execution isolated in `SaveIt.Job`, so `SaveIt.Bot` stays focused on workflow dispatch.

## Root Cause

The URL save flow matched the first progress `sendMessage` as `{:ok, progress_message}`. When ExGram returned a 429 error tuple, the handler crashed with a `MatchError`, so pending updates could be consumed without processing their URLs.

A second issue was ExGram's default polling worker starting with `offset: -1`, which asks Telegram for only the last pending update and drops older queued updates. The custom polling worker now omits the initial offset so Telegram returns pending updates from the earliest unconfirmed message.

## Release Candidate

- Published prerelease: `2026.7.6-rc.1`
- Release: https://github.com/ThaddeusJiang/save_it/releases/tag/2026.7.6-rc.1
- Workflow: https://github.com/ThaddeusJiang/save_it/actions/runs/28783477768
- Note: `2026.7.6-rc.1` was published before the Telegram pending-updates polling fix. Publish a new RC if this polling fix should be included in a prerelease artifact.

## Validation

- `mix test`
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix checks`
- `git diff --check`
